### PR TITLE
Fix for NPE preventing to launch SlipStream with a clean DB

### DIFF
--- a/clj/src/slipstream/ui/models/user.clj
+++ b/clj/src/slipstream/ui/models/user.clj
@@ -21,16 +21,16 @@
                         :super?     (-> attrs :issuper uc/parse-boolean)
                         :deleted?   (-> attrs :deleted uc/parse-boolean)
                         :configuration {:available-clouds (some-> parameters
-                                                            (parameters/value-for "General.default.cloud.service")
-                                                            (u/enum-update-name :available-clouds)
-                                                            (u/enum-sort-by :text)
-                                                            u/enum-flag-selected-as-default)
+                                                                  (parameters/value-for "General.default.cloud.service")
+                                                                  (u/enum-update-name :available-clouds)
+                                                                  (u/enum-sort-by :text)
+                                                                  u/enum-flag-selected-as-default)
                                         :keep-running     (some-> parameters
-                                                            (parameters/value-for "General.keep-running")
-                                                            u/enum-selection
-                                                            :value
-                                                            keyword)
+                                                                  (parameters/value-for "General.keep-running")
+                                                                  u/enum-selection
+                                                                  :value
+                                                                  keyword)
                                         :ssh-keys         (some-> parameters
-                                                            (parameters/value-for "General.ssh.public.key")
-                                                            s/trim
-                                                            not-empty)})))))
+                                                                  (parameters/value-for "General.ssh.public.key")
+                                                                  s/trim
+                                                                  not-empty)})))))

--- a/clj/src/slipstream/ui/models/user.clj
+++ b/clj/src/slipstream/ui/models/user.clj
@@ -20,18 +20,17 @@
                         :uri        (:resourceUri attrs)
                         :super?     (-> attrs :issuper uc/parse-boolean)
                         :deleted?   (-> attrs :deleted uc/parse-boolean)
-                        :configuration {:available-clouds (-> parameters
+                        :configuration {:available-clouds (some-> parameters
                                                             (parameters/value-for "General.default.cloud.service")
                                                             (u/enum-update-name :available-clouds)
                                                             (u/enum-sort-by :text)
                                                             u/enum-flag-selected-as-default)
-                                        :keep-running     (-> parameters
+                                        :keep-running     (some-> parameters
                                                             (parameters/value-for "General.keep-running")
                                                             u/enum-selection
                                                             :value
                                                             keyword)
-                                        :ssh-keys         (-> parameters
+                                        :ssh-keys         (some-> parameters
                                                             (parameters/value-for "General.ssh.public.key")
-                                                            (or "")
                                                             s/trim
                                                             not-empty)})))))

--- a/clj/src/slipstream/ui/views/modal_dialogs.clj
+++ b/clj/src/slipstream/ui/views/modal_dialogs.clj
@@ -128,9 +128,9 @@
 
 (defn- run-deployment-global-parameters
   [deployment-metadata]
-  {:deployment-target-cloud       (-> :available-clouds
-                                      current-user/configuration
-                                      (u/enum-append-option :specify-for-each-node))
+  {:deployment-target-cloud       (some-> :available-clouds
+                                          current-user/configuration
+                                          (u/enum-append-option :specify-for-each-node))
    :launch-mutable-run?           false
    :tolerate-deployment-failures? false
    :tags                          nil


### PR DESCRIPTION
This PR fixes an NPE that occurs when starting SlipStream with a clean DB. The NPE is due to the fact that no clouds are set up yet on a clean DB.

@st discovered that and we fixed and tested it together now.

This should go into the release, if possible.