### PR TITLE
hotfix: VMs section broken on Dashboard page

### DIFF
--- a/clj/src/slipstream/ui/models/vms.clj
+++ b/clj/src/slipstream/ui/models/vms.clj
@@ -11,7 +11,7 @@
                     :measurement])
       (assoc        :username           (-> vm-metadata :user       not-empty))
       (assoc        :cloud-instance-id  (-> vm-metadata :instanceId not-empty))
-      (assoc        :run-uuid           (-> vm-metadata :runUuid    (s/replace "Unknown" "") not-empty))
+      (assoc        :run-uuid           (some-> vm-metadata :runUuid  (s/replace "Unknown" "") not-empty))
       (assoc        :cloud-name         (-> vm-metadata :cloud      not-empty))
       (assoc        :ip-address         (-> vm-metadata :ip         not-empty))
       (assoc        :run-owner          (-> vm-metadata :runOwner   not-empty))

--- a/clj/src/slipstream/ui/models/vms.clj
+++ b/clj/src/slipstream/ui/models/vms.clj
@@ -11,7 +11,7 @@
                     :measurement])
       (assoc        :username           (-> vm-metadata :user       not-empty))
       (assoc        :cloud-instance-id  (-> vm-metadata :instanceId not-empty))
-      (assoc        :run-uuid           (some-> vm-metadata :runUuid  (s/replace "Unknown" "") not-empty))
+      (assoc        :run-uuid           (some-> vm-metadata :runUuid (s/replace "Unknown" "") not-empty))
       (assoc        :cloud-name         (-> vm-metadata :cloud      not-empty))
       (assoc        :ip-address         (-> vm-metadata :ip         not-empty))
       (assoc        :run-owner          (-> vm-metadata :runOwner   not-empty))

--- a/clj/test/slipstream/ui/models/vms_regular_user_test.clj
+++ b/clj/test/slipstream/ui/models/vms_regular_user_test.clj
@@ -9,7 +9,7 @@
       <vm cloud='CloudA' user='bob' state='Running' instanceId='4f2708e1-6aa6-4469-8f5e-b18ffd42cb50_machine' measurement='2014-12-08 13:09:24.82 CET' runUuid='a1b345f0-c434-490e-849f-c3894af55588' ip='127.0.0.1' name='machine' runOwner='super'/>
       <vm cloud='CloudA' user='bob' state='Terminated' instanceId='157701e9-9c52-45b1-a506-13241446aad3_machine' measurement='2014-12-08 13:09:24.98 CET' runUuid='a1b345f0-c434-490e-849f-c3894af55588' name='machine' runOwner='bob'/>
       <vm cloud='CloudA' user='bob' state='Running' instanceId='vm_gateway' measurement='2014-12-08 13:09:24.112 CET' runUuid='35c3789f-5da1-4504-8294-d41489d035ae' ip='127.0.0.1' name='vm_gateway' runOwner='super'/>
-      <vm cloud='CloudA' user='bob' state='Running' instanceId='vApp_6_centos' measurement='2014-12-08 13:09:24.126 CET' runUuid='Unknown'/>
+      <vm cloud='CloudA' user='bob' state='Running' instanceId='vApp_6_centos' measurement='2014-12-08 13:09:24.126 CET'/>
       <vm cloud='CloudA' user='bob' state='Running' instanceId='1b0afd4f-340d-4bef-89e2-d6f4a776f2ea' measurement='2014-12-08 13:09:33.215 CET' runUuid='Unknown'/>
       <user issuper='false' resourceUri='user/bob' name='bob'></user>
   </vms>")

--- a/clj/test/slipstream/ui/models/vms_super_test.clj
+++ b/clj/test/slipstream/ui/models/vms_super_test.clj
@@ -9,7 +9,7 @@
       <vm cloud='CloudA' user='bob' state='Running' instanceId='4f2708e1-6aa6-4469-8f5e-b18ffd42cb50_machine' measurement='2014-12-08 13:09:24.82 CET' runUuid='a1b345f0-c434-490e-849f-c3894af55588' ip='127.0.0.1' name='machine' runOwner='super'/>
       <vm cloud='CloudA' user='bob' state='Terminated' instanceId='157701e9-9c52-45b1-a506-13241446aad3_machine' measurement='2014-12-08 13:09:24.98 CET' runUuid='a1b345f0-c434-490e-849f-c3894af55588' name='machine' runOwner='bob'/>
       <vm cloud='CloudA' user='bob' state='Running' instanceId='vm_gateway' measurement='2014-12-08 13:09:24.112 CET' runUuid='35c3789f-5da1-4504-8294-d41489d035ae' ip='127.0.0.1' name='vm_gateway' runOwner='super'/>
-      <vm cloud='CloudA' user='bob' state='Running' instanceId='vApp_6_centos' measurement='2014-12-08 13:09:24.126 CET' runUuid='Unknown'/>
+      <vm cloud='CloudA' user='bob' state='Running' instanceId='vApp_6_centos' measurement='2014-12-08 13:09:24.126 CET'/>
       <vm cloud='CloudA' user='bob' state='Running' instanceId='1b0afd4f-340d-4bef-89e2-d6f4a776f2ea' measurement='2014-12-08 13:09:33.215 CET' runUuid='Unknown'/>
       <user issuper='true' resourceUri='user/super' name='super'></user>
   </vms>")


### PR DESCRIPTION
This PR fixes an NPE that appeared on VMs Section of Dashboard when at least one of the VMs reported in the metadata XML had no `runUuid` attribute. The NPE doesn't occur if the `runUuid` attribute is `Unknown` or an actual `uuid`.
