### PR TITLE
fix: initialize to blank string the provisioning alert message, #272

### DIFF
--- a/clj/resources/static_content/js/model.js
+++ b/clj/resources/static_content/js/model.js
@@ -471,8 +471,8 @@ jQuery( function() { ( function( $$, model, $, undefined ) {
                     },
 
                     handleOrchestratorStatecustom: function(state){
-                        var alertTitle = "Provisioning details",
-                            alertMessage;
+                        var alertTitle      = "Provisioning details",
+                            alertMessage    = "";
 
                         if (state === "Provisioning") {
                             $("[id^='parameter-orchestrator'][id*=':statecustom']", lastRefreshData).each(function() {


### PR DESCRIPTION
It is needed because some lines below we build the alertMessage string
with '+=', so that if we don't initialize it to blank string,
'undefined' is prepended at the begining of the alertMessage.

@loomis 
As suggested by @schaubl, this should also go into the v2.6.1 fix release.
Cheers.
