### PR TITLE
Fix runs order in dashboard.

### DIFF
--- a/clj/src/slipstream/ui/models/runs.clj
+++ b/clj/src/slipstream/ui/models/runs.clj
@@ -54,8 +54,7 @@
 (defn- parse-run-items
   [metadata]
   (->> (html/select metadata [:runs :item])
-       (map parse-run-item)
-       (sort-by :cloud-names)))
+       (map parse-run-item)))
 
 (defn parse
   [metadata]


### PR DESCRIPTION
Connected to #265.

They were being sorted by cloud on the UI side.
I removed this sorting, so that now the original order form the XML is maintained.