### PR TITLE
Make AJAX error reason more explicit

### DIFF
--- a/clj/resources/static_content/js/alert.js
+++ b/clj/resources/static_content/js/alert.js
@@ -59,7 +59,9 @@ jQuery( function() { ( function( $$, $, undefined ) {
         container: "floating",
         autoDismiss: true,
         title: undefined,
-        msg: undefined
+        titleMaxLength: 500,
+        msg: undefined,
+        msgMaxLength: 1500
     };
 
     function findVisibleAlerts($alertContainer) {
@@ -151,10 +153,12 @@ jQuery( function() { ( function( $$, $, undefined ) {
 
         $alertElem
             .find(".alert-msg")
-            .html(settings.msg);
+                .html(settings.msg.trimToMaxLength(settings.msgMaxLength));
 
         if (settings.title) {
-            $alertElem.find(".alert-title").html(settings.title);
+            $alertElem
+                .find(".alert-title")
+                    .html(settings.title.trimToMaxLength(settings.titleMaxLength));
         }
 
         if (! settings.isDismissible) {

--- a/clj/resources/static_content/js/request.js
+++ b/clj/resources/static_content/js/request.js
@@ -218,8 +218,9 @@ jQuery( function() { ( function( $$, $, undefined ) {
                                 responseDetail = $(jqXHR.responseText).find(".ss-header-subtitle").text();
                             }
                             $$.alert.showError(
-                                "Error " + jqXHR.status + " - " + errorThrown,
-                                responseDetail);
+                                responseDetail,
+                                "<code>Error " + jqXHR.status + " - " + errorThrown + "</code>"
+                                );
                         } else {
                             $$.alert.showError.apply(this, statusCodeAlertTitleAndMsg);
                         }

--- a/clj/resources/static_content/js/util.js
+++ b/clj/resources/static_content/js/util.js
@@ -12,6 +12,17 @@ jQuery( function() { ( function( $$, util, $, undefined ) {
             return (this.match(str + "$") == str);
         },
 
+        trimToMaxLength: function(maxLength, trimmingIndicatorStr) {
+            var trimWith = trimmingIndicatorStr === undefined ? "..." : trimmingIndicatorStr;
+            if ( trimWith.length >= maxLength ) {
+                throw "maxLength (" + maxLength + ") must be greater than the length of the trimmingIndicatorStr ('" + trimWith + "')";
+            } else if ( this.length > maxLength ) {
+                return this.substring(0, maxLength - trimWith.length).trimRight() + trimWith;
+            } else {
+                return this.toString();
+            }
+        },
+
         trimFromLastIndexOf: function(str) {
             var lastIndexOfStr = this.lastIndexOf(str);
             if (lastIndexOfStr === -1) {


### PR DESCRIPTION
Connected to #259.
Done by promoting AJAX error reason as alert title.
This only affects the AJAX requests done from the client browser with $$.request.* from request.js.

**Please take into account [this comment](https://github.com/slipstream/SlipStreamUI/issues/259#issuecomment-93702218) on the parent issue before merging.**

Cheers