### PR TITLE
Fix truncated cloud names in image cloud IDs table

### DIFF
--- a/clj/resources/static_content/css/content.css
+++ b/clj/resources/static_content/css/content.css
@@ -237,3 +237,7 @@ div.popover[role=tooltip]:not(.ss-alert-popover) code {
 #ssh-access-enabled + .help-block {
   max-width: 204px;
 }
+
+.ss-showing-full-text-on-hover {
+  color: transparent; /* hide real text */
+}

--- a/clj/resources/static_content/css/table.css
+++ b/clj/resources/static_content/css/table.css
@@ -27,6 +27,13 @@ td.ss-table-cell-boolean > input[type="checkbox"][disabled] {
   overflow: hidden;
 }
 
+.ss-table-cell-map .dl-horizontal > dt:hover:not(.ss-showing-full-text-on-hover) {
+  border-top:     1px solid #777;
+  border-bottom:  1px solid #777;
+  margin-top:     -1px;
+  margin-bottom:  -1px;
+}
+
 .ss-table-cell-reference-module-editable .input-group {
   width: 100%;
 }

--- a/clj/resources/static_content/css/table.css
+++ b/clj/resources/static_content/css/table.css
@@ -14,7 +14,7 @@ td.ss-table-cell-boolean > input[type="checkbox"][disabled] {
 .ss-table-cell-map dt,
 .ss-table-cell-map-editable dt,
 .ss-table-cell-deployment-node dt {
-  width: 130px;
+  width: 180px;
   text-align: left;
   clear: left;
   float: left;
@@ -22,7 +22,7 @@ td.ss-table-cell-boolean > input[type="checkbox"][disabled] {
 
 .ss-table-cell-map dd,
 .ss-table-cell-map-editable dd {
-  margin-left: 135px;
+  margin-left: 185px;
   text-overflow:ellipsis;
   overflow: hidden;
 }

--- a/clj/resources/static_content/js/util.js
+++ b/clj/resources/static_content/js/util.js
@@ -1505,7 +1505,8 @@ jQuery( function() { ( function( $$, util, $, undefined ) {
         },
 
         enableTooltipOnEllipsedTexts: function() {
-            var paddingTopBottomPx = 2,
+            var showingFullTextCls = "ss-showing-full-text-on-hover",
+                paddingTopBottomPx = 2,
                 paddingLeftRightPx = 6,
                 borderPx  = 1;
             this
@@ -1530,6 +1531,7 @@ jQuery( function() { ( function( $$, util, $, undefined ) {
                                 .hoverDelayed(
                                     function(){
                                         var pos = $this.position();
+                                        $this.addClass(showingFullTextCls);
                                         $thisFullForHover
                                             .css({
                                                 top:        pos.top  - paddingTopBottomPx - borderPx,
@@ -1539,6 +1541,7 @@ jQuery( function() { ( function( $$, util, $, undefined ) {
                                             .appendTo("body");
                                     },
                                     function() {
+                                        $this.removeClass(showingFullTextCls);
                                         $thisFullForHover.remove();
                                     },
                                     200);

--- a/clj/resources/static_content/js/util.js
+++ b/clj/resources/static_content/js/util.js
@@ -417,6 +417,7 @@ jQuery( function() { ( function( $$, util, $, undefined ) {
             },
 
             isNodeWithOverflow: function( index, element ) {
+                // Works only for visible elements (i.e. not with display: none).
                 return this.offsetWidth < this.scrollWidth;
             }
         },
@@ -1510,7 +1511,7 @@ jQuery( function() { ( function( $$, util, $, undefined ) {
                 paddingLeftRightPx = 6,
                 borderPx  = 1;
             this
-                .find("*:visible")
+                .find("*:visible:not(.sr-only)")
                     .filters(
                         this.predicates.isNodeWithOnlyText,
                         this.predicates.isNodeWithOverflow

--- a/clj/test/slipstream/ui/mockup_data/metadata_image.xml
+++ b/clj/test/slipstream/ui/mockup_data/metadata_image.xml
@@ -9,7 +9,7 @@
       <string>Cloud3</string>
       <string>Cloud4</string>
       <string>Cloud1</string>
-      <string>Cloud2</string>
+      <string>Cloud2-with-veeeery-long-name</string>
       <string>default</string>
    </cloudNames>
    <runs count="0" limit="20" offset="0" totalCount="0"/>

--- a/clj/test/slipstream/ui/models/module/image_test.clj
+++ b/clj/test/slipstream/ui/models/module/image_test.clj
@@ -264,7 +264,7 @@
                               :text "Other"}]
                     :login-username "centos_username"}
       :cloud-image-details {:native-image? false
-                            :cloud-identifiers {"Cloud2" nil
+                            :cloud-identifiers {"Cloud2-with-veeeery-long-name" nil
                                                 "Cloud1" nil
                                                 "Cloud4" nil
                                                 "Cloud3" nil}


### PR DESCRIPTION
Connected to #292.

The main changes are:

- The width of the cloud name column for the image cloud IDs table has been increased to accommodate the names up to a size similar to the one mentioned in the original issue (`ec2-ap-southeast-1`).

- A light visual cue on mouse-hover has been added to the cloud names in the image cloud IDs table to help with the bigger distance to the corresponding ID.
![screen shot 2015-04-23 at 13 46 14](https://cloud.githubusercontent.com/assets/807084/7296361/2dcccfa6-e9bf-11e4-86ce-d5adcdec2ee8.png)

- If the cloud name is still bigger than the available space, it will be truncated with ellipsis as of now, but the full name will be available on mouse-hover after a short delay. (This mechanism has been added in general to all instances of a truncated text.)
![screen shot 2015-04-23 at 13 46 20](https://cloud.githubusercontent.com/assets/807084/7296364/32dd2806-e9bf-11e4-96e9-adef1d288012.png)

