### PR TITLE
Deployments can be saved again consistently

### DIFF
--- a/clj/resources/static_content/js/base.js
+++ b/clj/resources/static_content/js/base.js
@@ -125,7 +125,6 @@ jQuery( function() { ( function( $$, $, undefined ) {
                         .addClass(discardedFormInputCls)
                         .disable();
             $(".ss-mapping-value input[type=text], .ss-mapping-value select")
-                .filter(":visible")
                 .not(":disabled")
                 .not(discardedFormInputCls.asSel())
                     .each(function (){


### PR DESCRIPTION
Connected to #295 

_Shown in today's demo. Related bug tracked in issue #300._

The issue was on the mechanism that ensures that the parameter values
are single-enquoted unless they are a mapping. Only `jQuery(":visible")`
input fields were analysed and single-enquoted. Therefore, if the
'Nodes' section (the second one) was not selected (i.e. not open) the
mechanism failed because the fields were not `:visible` and thus not
single-enquoted. Knowing this, the error message makes sense: SS expects
the parameter value to be a mapping (since it's not single-enquoted) but
the format is not correct to be a mapping.

Note that this points out also the two possible workarounds to make the
save action work as expected (with or without deployment modifications):

  1. clicking the 'Save' button with the 'Nodes' section open
     (recommended workaround)

  2. manually single-enquote all parameter values

This workarounds can be used (e.g. on the SaaS) until the new version is
deployed (or the bugfix applied).