### PR TITLE
Fix rendering of deployment UI page when a parameter had a value that matched the mapping pattern, i.e. "\w+:.*"

### DIFF
--- a/clj/resources/static_content/js/deployment.js
+++ b/clj/resources/static_content/js/deployment.js
@@ -235,8 +235,8 @@ jQuery( function() { ( function( $$, $, undefined ) {
         $(mappingOptionsComboBoxesSel).enable(shouldEnable);
     }
 
-    function isMappedValue(value) {
-        return value.match(/\w+:.*/) ? true : false;
+    function isMappedValue($inputElem) {
+        return $inputElem.closest("tr").find(".ss-mapping-options").val() === parameterBindToOutput;
     }
 
     // Next to each mapping input[type=text] we place a hidden combo for output bindings
@@ -252,7 +252,7 @@ jQuery( function() { ( function( $$, $, undefined ) {
                 .val(inputElemVal)
                 .end()
             .appendTo($mappingValueCell);
-        if (isMappedValue(inputElemVal)) {
+        if (isMappedValue($inputElem)) {
             // The value is nodename:outputname, so we can remove the content of the input[type=text]
             $inputElem.val("");
         }

--- a/clj/test/slipstream/ui/mockup_data/metadata_deployment.xml
+++ b/clj/test/slipstream/ui/mockup_data/metadata_deployment.xml
@@ -22,7 +22,7 @@
                <entry>
                   <string>input_param_2</string>
                   <parameter category="General" description="" isMappedValue="false" mandatory="false" name="input_param_2" order="0" order_="0" readonly="false" type="String">
-                     <value><![CDATA['default_value_for_input_param_2']]></value>
+                     <value><![CDATA['default:value_for_input_param_2_with_colon_in_the_name']]></value>
                   </parameter>
                </entry>
                <entry>

--- a/clj/test/slipstream/ui/models/module/deployment_test.clj
+++ b/clj/test/slipstream/ui/models/module/deployment_test.clj
@@ -37,7 +37,7 @@
                       :value "node2:output_param_1"}
                     {:name "input_param_2"
                      :mapped-value? false
-                     :value "'default_value_for_input_param_2'"}]}
+                     :value "'default:value_for_input_param_2_with_colon_in_the_name'"}]}
           {:name "node2"
              :template-node? nil
              :reference-image "neutral_projects_for_mockup_metadata/apache_web_server"


### PR DESCRIPTION
Now the JS does not rely on the pattern of the value to determine if it's a mapping or a plain value.

@konstan 
Please test it on your side before merging :wink: 
