### PR TITLE
Downgrade dependencies #201 #202 (fixes #201, fixes #202)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,10 +126,17 @@
         <dependency>
             <groupId>jline</groupId>
             <artifactId>jline</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>ring</groupId>
             <artifactId>ring</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>ring</groupId>
+            <artifactId>ring-core</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>net.cgrand</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,16 @@
             <groupId>clj-json</groupId>
             <artifactId>clj-json</artifactId>
         </dependency>
+        <dependency>
+            <groupId>net.cgrand</groupId>
+            <artifactId>moustache</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.clojure</groupId>
+            <artifactId>data.xml</artifactId>
+        </dependency>
 
+        <!-- test and debugging dependencies -->
         <dependency>
             <groupId>expectations</groupId>
             <artifactId>expectations</artifactId>
@@ -138,22 +147,7 @@
             <artifactId>ring-core</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>net.cgrand</groupId>
-            <artifactId>moustache</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.clojure</groupId>
-            <artifactId>data.xml</artifactId>
-        </dependency>
     </dependencies>
-    <repositories>
-        <repository>
-            <id>maven-restlet</id>
-            <name>Public online Restlet repository</name>
-            <url>http://maven.restlet.org</url>
-        </repository>
-    </repositories>
 
   <scm>
     <connection>${scm.read}/SlipStreamUI.git</connection>


### PR DESCRIPTION
This downgrades the dependencies for jline and ring, which should only be used for debugging and testing. Verify that this change does not interfere with the testing workflow.