### PR TITLE
Hotfix for the EEST timezone bug

### DIFF
--- a/clj/src/slipstream/ui/util/time.clj
+++ b/clj/src/slipstream/ui/util/time.clj
@@ -39,23 +39,35 @@
   #"\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d.\d\d\d(?:Z|[\+-]\d\d(?:\:?\d\d)?)")
 
 (def ^:private timezone-abbreviations
-  {;; Western European Time
-   "WEDT" "Europe/London"   ;; Western European Daylight Time
-   "WEST" "Europe/London"   ;; Western European Summer Time
-   "WET"  "Europe/London"   ;; Western European Time
-   "BST"  "Europe/London"   ;; British Summer Time
-   "GMT"  "Europe/London"   ;; Greenwich Mean Time
+  {;; Pacific Time (North America)
+   "PDT" "America/Los_Angeles"  ;;Pacific Daylight Time (North America)
+   "PST" "America/Los_Angeles"  ;;Pacific Standard Time (North America)
+   ;; Mountain Time (North America)
+   "MDT" "America/Denver"       ;; Mountain Daylight Time (North America)
+   "MST" "America/Denver"       ;; Mountain Standard Time (North America)
+   ;; Central Time (North America)
+   "CDT" "America/Chicago"      ;; Central Daylight Time (North America)
+   "CST" "America/Chicago"      ;; Central Standard Time (North America)
+   ;; Eastern Time (North America)
+   "EDT" "America/Montreal"     ;; Eastern Daylight Time (North America)
+   "EST" "America/Montreal"     ;; Eastern Standard Time (North America)
+   ;; Western European Time
+   "WEDT" "Europe/London"       ;; Western European Daylight Time
+   "WEST" "Europe/London"       ;; Western European Summer Time
+   "WET"  "Europe/London"       ;; Western European Time
+   "BST"  "Europe/London"       ;; British Summer Time
+   "GMT"  "Europe/London"       ;; Greenwich Mean Time
    ;; Central European Time
-   "CEDT" "Europe/Paris"    ;; Central European Daylight Time
-   "CEST" "Europe/Paris"    ;; Central European Summer Time (Cf. HAEC)
-   "CET"  "Europe/Paris"    ;; Central European Time
-   "HAEC" "Europe/Paris"    ;; Heure Avancée d'Europe Centrale francised name for CEST
-   "MET"  "Europe/Paris"    ;; Middle European Time, same zone as CET
-   "MEST" "Europe/Paris"    ;; Middle European Saving Time, same zone as CEST
+   "CEDT" "Europe/Paris"        ;; Central European Daylight Time
+   "CEST" "Europe/Paris"        ;; Central European Summer Time (Cf. HAEC)
+   "CET"  "Europe/Paris"        ;; Central European Time
+   "HAEC" "Europe/Paris"        ;; Heure Avancée d'Europe Centrale francised name for CEST
+   "MET"  "Europe/Paris"        ;; Middle European Time, same zone as CET
+   "MEST" "Europe/Paris"        ;; Middle European Saving Time, same zone as CEST
    ;; Eastern European Time
-   "EEDT" "Europe/Athens"   ;; Eastern European Daylight Time
-   "EEST" "Europe/Athens"   ;; Eastern European Summer Time
-   "EET"  "Europe/Athens"   ;; Eastern European Time
+   "EEDT" "Europe/Athens"       ;; Eastern European Daylight Time
+   "EEST" "Europe/Athens"       ;; Eastern European Summer Time
+   "EET"  "Europe/Athens"       ;; Eastern European Time
   })
 
 (definline ^:private normalize-timezone

--- a/clj/src/slipstream/ui/util/time.clj
+++ b/clj/src/slipstream/ui/util/time.clj
@@ -40,14 +40,19 @@
 
 (defn- normalize-timezone
   "The timezone code CEST is not recognized as standard by org.joda.time.
-  For a complete list of supported timezones run:
-    (org.joda.time.DateTimeZone/getAvailableIDs)"
+  For a complete list of supported timezones run in the REPL:
+    (org.joda.time.DateTimeZone/getAvailableIDs)
+  For a list of timezone abbreviations visit:
+    http://en.wikipedia.org/wiki/List_of_time_zone_abbreviations"
   [s]
   (-> s
       (s/replace "CET"  "Europe/Paris")
       (s/replace "CEST" "Europe/Paris")
       (s/replace "BST"  "Europe/London")
-      (s/replace "GMT"  "Europe/London")))
+      (s/replace "GMT"  "Europe/London")
+      (s/replace "EET"  "Europe/Athens")
+      (s/replace "EEDT" "Europe/Athens")
+      (s/replace "EEST" "Europe/Athens")))
 
 
 (defn- formatters

--- a/clj/src/slipstream/ui/util/time.clj
+++ b/clj/src/slipstream/ui/util/time.clj
@@ -38,22 +38,36 @@
   "Corresponds to (clj-time.format/formatters :date-time)."
   #"\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d.\d\d\d(?:Z|[\+-]\d\d(?:\:?\d\d)?)")
 
-(defn- normalize-timezone
+(def ^:private timezone-abbreviations
+  {;; Western European Time
+   "WEDT" "Europe/London"   ;; Western European Daylight Time
+   "WEST" "Europe/London"   ;; Western European Summer Time
+   "WET"  "Europe/London"   ;; Western European Time
+   "BST"  "Europe/London"   ;; British Summer Time
+   "GMT"  "Europe/London"   ;; Greenwich Mean Time
+   ;; Central European Time
+   "CEDT" "Europe/Paris"    ;; Central European Daylight Time
+   "CEST" "Europe/Paris"    ;; Central European Summer Time (Cf. HAEC)
+   "CET"  "Europe/Paris"    ;; Central European Time
+   "HAEC" "Europe/Paris"    ;; Heure Avancée d'Europe Centrale francised name for CEST
+   "MET"  "Europe/Paris"    ;; Middle European Time, same zone as CET
+   "MEST" "Europe/Paris"    ;; Middle European Saving Time, same zone as CEST
+   ;; Eastern European Time
+   "EEDT" "Europe/Athens"   ;; Eastern European Daylight Time
+   "EEST" "Europe/Athens"   ;; Eastern European Summer Time
+   "EET"  "Europe/Athens"   ;; Eastern European Time
+  })
+
+(definline ^:private normalize-timezone
   "The timezone code CEST is not recognized as standard by org.joda.time.
   For a complete list of supported timezones run in the REPL:
     (org.joda.time.DateTimeZone/getAvailableIDs)
   For a list of timezone abbreviations visit:
     http://en.wikipedia.org/wiki/List_of_time_zone_abbreviations"
   [s]
-  (-> s
-      (s/replace "CET"  "Europe/Paris")
-      (s/replace "CEST" "Europe/Paris")
-      (s/replace "BST"  "Europe/London")
-      (s/replace "GMT"  "Europe/London")
-      (s/replace "EET"  "Europe/Athens")
-      (s/replace "EEDT" "Europe/Athens")
-      (s/replace "EEST" "Europe/Athens")))
-
+  `(-> ~s
+     ~@(for [[timezone abbreviations] (group-by val timezone-abbreviations)]
+      `(s/replace ~(->> abbreviations (map first) (s/join "|") re-pattern) ~timezone))))
 
 (defn- formatters
   [formatter]

--- a/clj/test/slipstream/ui/util/time_test.clj
+++ b/clj/test/slipstream/ui/util/time_test.clj
@@ -14,6 +14,10 @@
 (def normalize-timezone @#'slipstream.ui.util.time/normalize-timezone)
 
 (expect
+  "2013-07-05 00:27:12.471 America/Chicago"
+  (normalize-timezone "2013-07-05 00:27:12.471 CST"))
+
+(expect
   "2013-07-05 00:27:12.471 Europe/Paris"
   (normalize-timezone "2013-07-05 00:27:12.471 CEST"))
 
@@ -26,9 +30,13 @@
   (normalize-timezone "2013-01-05T01:27:12.471+0100"))
 
 (expect
-  {"Europe/London" 5
-   "Europe/Paris"  6
-   "Europe/Athens" 3}
+  {"America/Los_Angeles"  2
+   "America/Denver"       2
+   "America/Chicago"      2
+   "America/Montreal"     2
+   "Europe/London"        5
+   "Europe/Paris"         6
+   "Europe/Athens"        3}
   (->> @#'slipstream.ui.util.time/timezone-abbreviations
        keys
        (map normalize-timezone)

--- a/clj/test/slipstream/ui/util/time_test.clj
+++ b/clj/test/slipstream/ui/util/time_test.clj
@@ -9,6 +9,33 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+;; private fn normalize-timezone
+
+(def normalize-timezone @#'slipstream.ui.util.time/normalize-timezone)
+
+(expect
+  "2013-07-05 00:27:12.471 Europe/Paris"
+  (normalize-timezone "2013-07-05 00:27:12.471 CEST"))
+
+(expect
+  "2013-07-05 00:27:12.471 Europe/Athens"
+  (normalize-timezone "2013-07-05 00:27:12.471 EEST"))
+
+(expect
+  "2013-01-05T01:27:12.471+0100"
+  (normalize-timezone "2013-01-05T01:27:12.471+0100"))
+
+(expect
+  {"Europe/London" 5
+   "Europe/Paris"  6
+   "Europe/Athens" 3}
+  (->> @#'slipstream.ui.util.time/timezone-abbreviations
+       keys
+       (map normalize-timezone)
+       frequencies))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 ;; parse SlipStream timestamp format
 
 (expect


### PR DESCRIPTION
Connected to #308 

@konstan 

The patch you hot-applied is equivalent to the first commit (i.e. 3081c6409482db0f27398ade2345ea5129ec7314) in this PR.

Further I added checks for some additional timezone abbreviations trying to prevent some new cases of this bug until the proper fix (i.e. using `ISO 8601` timestamp format, as in slipstream/SlipStreamServer#349). Please test this on your side as far and you can.

Cheers.