### PR TITLE
fix: now input/output category can only be changed for new params

### DIFF
--- a/clj/src/slipstream/ui/views/tables.clj
+++ b/clj/src/slipstream/ui/views/tables.clj
@@ -400,9 +400,9 @@
                :value "String"}})
 
   (defmethod deployment-parameter-cell :category
-    [row-index {:keys [disabled? placeholder category] :as param} field]
+    [row-index {:keys [disabled? placeholder category blank-row?] :as param} field]
     {:type      :cell/enum
-     :editable? (page-type/edit-or-new?)
+     :editable? blank-row?
      :content {:disabled? disabled?
                :id (when-not disabled? (deployment-parameter-cell-id row-index field))
                :enum (u/enum ["Output" "Input"] :deployment-parameter-category category)}})


### PR DESCRIPTION
Connected to #278 

Previously, the parameter category (i.e. input or output) for existent
parameters could be changed when editing the image, but the change is
(as of now) not taken into account by the server.