### PR TITLE
Make it compile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,11 +84,7 @@
                             <workingDirectory>cljs</workingDirectory>
                             <executable>lein</executable>
                             <arguments>
-                                <argument>do</argument>
                                 <argument>deps</argument>
-                                <argument>,</argument>
-                                <argument>cljsbuild</argument>
-                                <argument>once</argument>
                             </arguments>
                         </configuration>
                     </execution>


### PR DESCRIPTION
Fix build : deps stage
https://github.com/slipstream/SlipStream/issues/70

Build failure :
[...]
[INFO] --- exec-maven-plugin:1.4.0:exec (cljs-build) @ SlipStreamUI ---
[...]
[DEBUG] Executing command line: [lein, do, deps, ,, cljsbuild, once]
That's not a task. Use "lein help" to list all tasks.
[...]

Please advise if this is not the right fix.