### PR TITLE
Alerts are now displayed for a sensible amount of time, depending on the length of the content text.

### DIFF
--- a/clj/resources/static_content/js/alert.js
+++ b/clj/resources/static_content/js/alert.js
@@ -14,8 +14,8 @@ jQuery( function() { ( function( $$, $, undefined ) {
         // Wait longer for longer messages.
         var minDelay = 5000,
             delayMillisPerChar = 100, // empirical value
-            msg = $alertElem.find(".alert-msg").text();
-            delay = Math.max(minDelay, delayMillisPerChar * msg.countNonWhitespaceChars());
+            text = $alertElem.find(".alert-title").text() + $alertElem.find(".alert-msg").text();
+            delay = Math.max(minDelay, delayMillisPerChar * text.countNonWhitespaceChars());
         $alertElem.scheduleAlertDismiss(delay);
     }
 


### PR DESCRIPTION
Connected to #318

Now we take into account the alert title to calculate read time. Previously it was only the alert message, explaining the behaviour in the related issue.