### PR TITLE
Make refresh of run page async to avoid blocking the UI.

### DIFF
--- a/clj/resources/static_content/js/model.js
+++ b/clj/resources/static_content/js/model.js
@@ -233,7 +233,6 @@ jQuery( function() { ( function( $$, model, $, undefined ) {
             }
             var isRun   = $$.util.meta.isViewName("run", $elem),
                 finalStates = ["cancelled", "aborted", "done"],
-                checkLoginRequest,
                 refreshRequest,
                 uuid,
                 url,
@@ -544,23 +543,18 @@ jQuery( function() { ( function( $$, model, $, undefined ) {
                             $(document).trigger("runUpdated", {"context": lastRefreshData});
                         }
 
-                        if (! checkLoginRequest) {
-                            checkLoginRequest = $$.request
-                                                    .get($("#ss-menubar-user-profile-anchor").attr("href"))
-                                                    .async(false)
-                                                    .dataType("xml")
-                                                    .onError(function() {
-                                                        $$.util.url.reloadPage();
-                                                    });
-                        }
                         if (! refreshRequest) {
                             refreshRequest = $$.request
                                                 .get(runModel.getURL())
-                                                .async(false)
                                                 .dataType("html")
-                                                .onSuccess(refreshCallback);
+                                                .onSuccess(refreshCallback)
+                                                .onErrorStatusCode(
+                                                    401, // Unauthorized
+                                                    function() {
+                                                        // Reload page to force going to login
+                                                        $$.util.url.reloadPage();
+                                                    });
                         }
-                        checkLoginRequest.send();
                         refreshRequest.send();
                         return runModel;
                     },

--- a/clj/resources/static_content/js/request.js
+++ b/clj/resources/static_content/js/request.js
@@ -217,7 +217,7 @@ jQuery( function() { ( function( $$, $, undefined ) {
                         }
                         var statusCodeCallback = errorStatusCodeCallbacks[jqXHR.status];
                         if ( $$.util.isSomething.callable(statusCodeCallback) ) {
-                            statusCodeCallback.call(jqXHR.status, jqXHR, textStatus, errorThrown);
+                            statusCodeCallback.call(this, jqXHR.status, jqXHR, textStatus, errorThrown);
                         }
                         var statusCodeAlertTitleAndMsg = errorStatusCodeAlerts[jqXHR.status];
                         if (statusCodeAlertTitleAndMsg === undefined) {

--- a/clj/resources/static_content/js/request.js
+++ b/clj/resources/static_content/js/request.js
@@ -6,6 +6,7 @@ jQuery( function() { ( function( $$, $, undefined ) {
                 serialization: undefined,           // See .serialization() fn below
                 onDataTypeParseError: undefined,    // See .onDataTypeParseErrorAlert() fn below
                 always: undefined,                  // See .always() fn below
+                errorStatusCodeCallbacks: {},       // See .onErrorStatusCode() fn below
                 errorStatusCodeAlerts: {},          // See .onErrorStatusCodeAlert() fn below
                 validation: undefined               // See .validation() fn below
             },
@@ -133,6 +134,10 @@ jQuery( function() { ( function( $$, $, undefined ) {
                 this.onError(showErrorAlert);
                 return this;
             },
+            onErrorStatusCode: function (statusCode, callback){
+                $$.util.object.setOrPush(this.intern.errorStatusCodeCallbacks, statusCode, callback);
+                return this;
+            },
             onErrorStatusCodeAlert: function (statusCode, titleOrMsg, msg){
                 this.intern.errorStatusCodeAlerts[statusCode] = [titleOrMsg, msg];
                 return this;
@@ -204,10 +209,15 @@ jQuery( function() { ( function( $$, $, undefined ) {
                      "refreshing this page and doing the request again.");
 
                 if (!this.intern.defaultErrorHandlerAlreadySetup) {
-                    var errorStatusCodeAlerts = this.intern.errorStatusCodeAlerts;
+                    var errorStatusCodeCallbacks = this.intern.errorStatusCodeCallbacks,
+                        errorStatusCodeAlerts    = this.intern.errorStatusCodeAlerts;
                     this.onError( function(jqXHR, textStatus, errorThrown){
                         if (textStatus != "error") {
                             return;
+                        }
+                        var statusCodeCallback = errorStatusCodeCallbacks[jqXHR.status];
+                        if ( $$.util.isSomething.callable(statusCodeCallback) ) {
+                            statusCodeCallback.call(jqXHR.status, jqXHR, textStatus, errorThrown);
                         }
                         var statusCodeAlertTitleAndMsg = errorStatusCodeAlerts[jqXHR.status];
                         if (statusCodeAlertTitleAndMsg === undefined) {

--- a/clj/resources/static_content/js/util.js
+++ b/clj/resources/static_content/js/util.js
@@ -1,5 +1,20 @@
 jQuery( function() { ( function( $$, util, $, undefined ) {
 
+
+    util.isSomething = {
+        implementingMethod: function (something, methodName) {
+            try {
+                return $.type(something[methodName]) === "function";
+            }
+            catch (e) {
+                return false;
+            }
+        },
+        callable: function (something) {
+            return util.isSomething.implementingMethod(something, "call");
+        }
+    };
+
     // String prototype extensions
 
     $.extend(String.prototype, {


### PR DESCRIPTION
Connected to #368.

Please note that as [commented](https://github.com/slipstream/SlipStreamUI/issues/368#issuecomment-121999979) in the corresponding issue #368, the authentication check done by [this line](https://github.com/slipstream/SlipStreamUI/blob/b628f827e02b09a9501a9e62941ff02895c98616/clj/resources/static_content/js/model.js#L552-L555) will not work until the bug slipstream/SlipStreamServer#422 in the server is fixed. But this is less of an issue now that the authentication token is valid for a week.

@konstan With this patch you should not see the UI on the run page blocking anymore, even is the server infrastructure takes longtime to answer.