### PR TITLE
Correctly pick the publication date of a module.

### DIFF
--- a/clj/src/slipstream/ui/models/module.clj
+++ b/clj/src/slipstream/ui/models/module.clj
@@ -70,7 +70,7 @@
   [metadata]
   (let [attrs (:attrs metadata)
         alternative-uri (str (:parentUri attrs) "/" (:shortName attrs))
-        publication-date (-> metadata (html/select [:published]) first :attrs :publicationDate)]
+        publication-date (-> metadata (html/select [html/root :> :published]) first :attrs :publicationDate)]
     {:description       (-> attrs :description)
      :category          (-> attrs :category)
      :comment           (-> metadata (html/select [html/root :> :commit :comment html/text]) first)


### PR DESCRIPTION
Connected to #281

This one is really tiny. I'm merging it myself, since there is a bit of PR-jam.