### PR TITLE
Add 'Terminate' action in runs table in Dashboard.

### DIFF
--- a/clj/resources/lang/en.edn
+++ b/clj/resources/lang/en.edn
@@ -90,9 +90,13 @@
                     :repository       "Repository"
                     :run              "Run"
                     :runs             "Runs"
+                    :run-id           "Run Id"
+                    :run-type         "Run Type"
                     :service-catalog  "Service Catalog"
+                    :service-url      "Service URL"
                     :severity         "Severity"
                     :start            "Start"
+                    :start-time       "Start Time"
                     :state            "State"
                     :success          "Success"
                     :summary          "Summary"
@@ -303,10 +307,10 @@
    :slipstream.ui.views.table.header.pdf                      :global.nouns.pdf
    :slipstream.ui.views.table.header.public                   :global.nouns.public
    :slipstream.ui.views.table.header.repository               :global.nouns.repository
-   :slipstream.ui.views.table.header.run-id                   "Run Id"
+   :slipstream.ui.views.table.header.run-id                   :global.nouns.run-id
    :slipstream.ui.views.table.header.run-owner                "Run Owner"
    :slipstream.ui.views.table.header.slipstream-id            "SlipStream ID"
-   :slipstream.ui.views.table.header.start-time               "Start Time"
+   :slipstream.ui.views.table.header.start-time               :global.nouns.start-time
    :slipstream.ui.views.table.header.state                    :global.nouns.state
    :slipstream.ui.views.table.header.status                   :global.nouns.state
    :slipstream.ui.views.table.header.tags                     :global.nouns.tags
@@ -346,6 +350,7 @@
    :slipstream.ui.util.core.enum.option.text.mapping-options.parameter.bind-to-output  "Map to output parameter of another node"
    :slipstream.ui.util.core.enum.option.text.mapping-options.parameter.bind-to-value   "Default value"
 
+   :slipstream.ui.views.tables.button-label.terminate :global.verbs.terminate
 
    :slipstream.ui.views.tables.deployment-nodes-table.new-parameter-mapping.placeholder.value   "No value"
 
@@ -522,10 +527,10 @@
    :slipstream.ui.models.parameters.end-time.description                        :global.nouns.end
    :slipstream.ui.models.parameters.end-time.help-hint                          ""
 
-   :slipstream.ui.models.parameters.run-type.description                        "Run Type"
+   :slipstream.ui.models.parameters.run-type.description                        :global.nouns.run-type
    :slipstream.ui.models.parameters.run-type.help-hint                          ""
 
-   :slipstream.ui.models.parameters.run-id.description                          "Run Id"
+   :slipstream.ui.models.parameters.run-id.description                          :global.nouns.run-id
    :slipstream.ui.models.parameters.run-id.help-hint                            ""
 
    :slipstream.ui.models.parameters.tags.description                            :global.nouns.tags
@@ -993,9 +998,19 @@
    :slipstream.ui.views.modal-dialogs.image-chooser-dialog.button.select-exact-version "Select exact version"
 
    :slipstream.ui.views.modal-dialogs.terminate-deployment-dialog.title         "Terminate deployment"
-   :slipstream.ui.views.modal-dialogs.terminate-deployment-dialog.question      "Are you sure you want to terminate all virtual machines running in this deployment?"
+   :slipstream.ui.views.modal-dialogs.terminate-deployment-dialog.question      "Are you sure you want to terminate all virtual machines running in this deployment? Note that this cannot be undone."
    :slipstream.ui.views.modal-dialogs.terminate-deployment-dialog.button.cancel :global.verbs.cancel
    :slipstream.ui.views.modal-dialogs.terminate-deployment-dialog.button.terminate :global.verbs.terminate
+
+   :slipstream.ui.views.modal-dialogs.terminate-deployment-dialog.label.deployment-run-id      :global.nouns.run-id
+   :slipstream.ui.views.modal-dialogs.terminate-deployment-dialog.label.deployment-run-type    :global.nouns.run-type
+   :slipstream.ui.views.modal-dialogs.terminate-deployment-dialog.label.deployment-module      :global.nouns.module
+   :slipstream.ui.views.modal-dialogs.terminate-deployment-dialog.label.deployment-state       :global.nouns.state
+   :slipstream.ui.views.modal-dialogs.terminate-deployment-dialog.label.deployment-start-time  :global.nouns.start-time
+   :slipstream.ui.views.modal-dialogs.terminate-deployment-dialog.label.deployment-clouds      :global.nouns.clouds
+   :slipstream.ui.views.modal-dialogs.terminate-deployment-dialog.label.deployment-service-url :global.nouns.service-url
+   :slipstream.ui.views.modal-dialogs.terminate-deployment-dialog.label.deployment-user        :global.nouns.user
+   :slipstream.ui.views.modal-dialogs.terminate-deployment-dialog.label.deployment-tags        :global.nouns.tags
 
    :slipstream.ui.views.modal-dialogs.publish-module-confirmation-dialog.title                "Publish %1$s" ;  %1$s: module category
    :slipstream.ui.views.modal-dialogs.publish-module-confirmation-dialog.question             "Do you want to publish the %1$s `%2$s` (v %3$s) in the [App Store](/)?"  ;  %1$s: module category ;  %2$s: module name ;  %3$s: module version

--- a/clj/resources/lang/fr.edn
+++ b/clj/resources/lang/fr.edn
@@ -345,6 +345,8 @@
    :slipstream.ui.util.core.enum.option.text.mapping-options.parameter.bind-to-output  "Lié à un paramètre de sortie d'un autre noeud"
    :slipstream.ui.util.core.enum.option.text.mapping-options.parameter.bind-to-value   "Valeur par défaut"
 
+   :slipstream.ui.views.tables.button-label.terminate :global.verbs.terminate
+
    :slipstream.ui.views.tables.deployment-nodes-table.new-parameter-mapping.placeholder.value "Pas de valeur"
 
    :slipstream.ui.views.table.reference-module-cell.chooser-button.label "Choisir la référence"

--- a/clj/resources/static_content/css/content.css
+++ b/clj/resources/static_content/css/content.css
@@ -71,6 +71,8 @@ tr.text-danger a {
 .ss-alert-popover-error a,
 .text-danger a,
 .has-error code,
+.panel-danger .panel-heading code,
+.ss-abort-message code,
 .has-error .ss-validation-help-hint a,
 .alert-danger code {
   color: #a94442;

--- a/clj/resources/static_content/css/modal_dialogs.css
+++ b/clj/resources/static_content/css/modal_dialogs.css
@@ -61,3 +61,11 @@
 #ss-start-tour-dialog .ss-dialog-footnote {
   padding-top: 15px;
 }
+
+.ss-deployment-info {
+  padding-top: 25px;
+}
+
+#ss-terminate-deployment-from-dashboard-dialog .modal-title code {
+      background-color: transparent;
+}

--- a/clj/resources/static_content/js/request.js
+++ b/clj/resources/static_content/js/request.js
@@ -222,6 +222,11 @@ jQuery( function() { ( function( $$, $, undefined ) {
                 this.onError(showErrorAlert);
                 return this;
             },
+            onErrorAlertFixed: function (titleOrMsg, msg){
+                var showErrorAlertFixed = function () { $$.alert.showErrorFixed(titleOrMsg, msg); };
+                this.onError(showErrorAlertFixed);
+                return this;
+            },
             onErrorStatusCode: function (statusCode, callback){
                 $$.util.object.setOrPush(this.intern.errorStatusCodeCallbacks, statusCode, callback);
                 return this;

--- a/clj/resources/static_content/js/table.js
+++ b/clj/resources/static_content/js/table.js
@@ -161,4 +161,65 @@ jQuery( function() { ( function( $$, $, undefined ) {
 
     });
 
+    $("body").on("click", ".ss-terminate-run-from-table-button", function() {
+        var $terminateButton = $(this),
+            $runRow = $terminateButton.closest("tr")
+                                .clone()
+                                    .find("a")
+                                        .attr("target", "_blank")
+                                    .end(),
+            $stateIcon   = $runRow.find("td:nth-child(1)"),
+            $runTypeIcon = $runRow.find("td:nth-child(2) .glyphicon"),
+            runTypeHTML  = "<span>" +
+                            $runTypeIcon.get(0).outerHTML +
+                            " " +
+                            $runTypeIcon.data("original-title") +
+                           "</span>",
+            $runID       = $runRow.find("td:nth-child(3)"),
+            runID        = $runID.find("a").html(),
+            runURI       = $runID.find("a").attr("href"),
+            $module      = $runRow.find("td:nth-child(4)"),
+            $state       = $runRow.find("td:nth-child(5)"),
+            abortMsgHTML = "<div class='ss-abort-message text-danger'>" +
+                            ($runRow.dataIn("fromServer.alertPopoverOptions.content") || '') +
+                            "</div>",
+            $startTime   = $runRow.find("td:nth-child(6)"),
+            $clouds      = $runRow.find("td:nth-child(7)"),
+            $user        = $runRow.find("td:nth-child(8)"),
+            $tags        = $runRow.find("td:nth-child(9)");
+        $('#ss-terminate-deployment-from-table-dialog')
+            .replaceHTMLContentBySelector({
+                ".modal-title .ss-deployment-run-id": runID,
+                "dd.ss-deployment-run-id":            $runID.html(),
+                ".ss-deployment-run-type":            runTypeHTML,
+                ".ss-deployment-module":              $module.html(),
+                ".ss-deployment-state":               $state
+                                                            .prepend($stateIcon.html())
+                                                            .append(abortMsgHTML)
+                                                            .html(),
+                ".ss-deployment-start-time":          $startTime.html(),
+                ".ss-deployment-clouds":              $clouds.html(),
+                ".ss-deployment-service-url":         '', // TODO
+                ".ss-deployment-user":                $user.html(),
+                ".ss-deployment-tags":                $tags.html()
+            })
+            .askConfirmation(function(){
+                $terminateButton
+                    .addClass("disabled")
+                    .find(".glyphicon")
+                        .addClass("ss-icon-loading");
+                console.info("Terminating deployment: " + runURI);
+                $$.request
+                    .delete(runURI)
+                    .onErrorAlertFixed(
+                        "Run <a href='" + runURI + "'><code>" + runID + "</code></a> failed to terminate properly."
+                        )
+                    .always(function(){
+                        console.log("request to terminate done");
+                        $(".ss-dynamic-content").trigger("ss-dynamic-content-reload");
+                    })
+                    .send();
+            });
+    });
+
 }( window.SlipStream = window.SlipStream || {}, jQuery ));});

--- a/clj/resources/static_content/js/util.js
+++ b/clj/resources/static_content/js/util.js
@@ -1579,6 +1579,21 @@ jQuery( function() { ( function( $$, util, $, undefined ) {
             return this.updateContent(this.html, this.html, newHTML, todoIfUpdated, callbackIfUpdated);
         },
 
+        replaceHTMLContentBySelector: function(selectorsAndContentsMap) {
+            if ( $.type(selectorsAndContentsMap) !== "object" ) {
+                console.warn("selectorsAndContentsMap must be a map of selectors to jQuery elements or HTML strings.");
+                return this;
+            }
+            var $this = this;
+            $.each(selectorsAndContentsMap, function(sel, newHTMLString) {
+                $this
+                    .find(sel)
+                        .html(newHTMLString)
+                        .bsEnableDynamicElements();
+            });
+            return $this;
+        },
+
         // Bottom shadow
 
         _onScrollCallbackToAdjustIFrameBottomShadowOpacity: function (iFrameHeight, $bottomShadow){

--- a/clj/src/slipstream/ui/models/runs.clj
+++ b/clj/src/slipstream/ui/models/runs.clj
@@ -31,6 +31,11 @@
     ;;       Should properly log this.
     nil))
 
+(def ^:private terminated-states
+  #{"Finalizing"
+    "Done"
+    "Aborted"
+    "Cancelled"})
 
 (defn- parse-run-item
   [run-item-metadata]
@@ -47,6 +52,7 @@
         (assoc        :abort-flag?    abort-flag?)
         (assoc        :display-status (display-status (:status attrs) abort-flag?))
         (assoc        :type           (-> attrs :type run/run-type-mapping))
+        (assoc        :terminable?    (-> attrs :status terminated-states not))
         (assoc        :module-uri     (-> attrs :moduleResourceUri))
         (assoc        :uri            (-> attrs :resourceUri))
         (assoc        :cloud-names    (-> attrs :cloudServiceNames)))))

--- a/clj/src/slipstream/ui/views/html/modal_dialogs.html
+++ b/clj/src/slipstream/ui/views/html/modal_dialogs.html
@@ -202,6 +202,54 @@
       </div>
     </div>
 
+    <p>
+
+    <!-- Button trigger modal -->
+    <button class="btn btn-primary btn-lg" data-toggle="modal" data-target="#ss-terminate-deployment-from-table-dialog">
+      Launch demo <code>#ss-terminate-deployment-from-table-dialog</code> modal
+    </button>
+
+    <!-- Modal -->
+    <div class="modal fade" id="ss-terminate-deployment-from-table-dialog" tabindex="-1" role="dialog" aria-labelledby="ss-terminate-deployment-from-table-dialog-label" aria-hidden="true">
+      <div class="modal-dialog">
+        <div class="modal-content panel-danger">
+          <div class="modal-header panel-heading">
+            <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
+            <h4 class="modal-title"><span id="ss-terminate-deployment-from-table-dialog-label">Terminate deployment</span> <code><span class="ss-deployment-run-id">Example Run Id</span></code> </h4>
+          </div>
+          <div class="modal-body">
+            <div class="message">
+              Are you sure you want to terminate all virtual machines running in this deployment?
+            </div>
+            <dl class="dl-horizontal ss-deployment-info">
+              <dt class="ss-deployment-run-id-label">Run Id</dt>
+              <dd class="ss-deployment-run-id">Example Run Id</dd>
+              <dt class="ss-deployment-run-type-label">Run Type</dt>
+              <dd class="ss-deployment-run-type">Example Run Type</dd>
+              <dt class="ss-deployment-module-label">Module</dt>
+              <dd class="ss-deployment-module">Example Module</dd>
+              <dt class="ss-deployment-state-label">State</dt>
+              <dd class="ss-deployment-state">Example State</dd>
+              <dt class="ss-deployment-start-time-label">Start Time</dt>
+              <dd class="ss-deployment-start-time">Example Start Time</dd>
+              <dt class="ss-deployment-clouds-label">Clouds</dt>
+              <dd class="ss-deployment-clouds">Example Clouds</dd>
+              <dt class="ss-deployment-service-url-label">Service URL</dt>
+              <dd class="ss-deployment-service-url">Example Service URL</dd>
+              <dt class="ss-deployment-user-label">User</dt>
+              <dd class="ss-deployment-user">Example User</dd>
+              <dt class="ss-deployment-tags-label">Tags</dt>
+              <dd class="ss-deployment-tags">Example Tags</dd>
+            </dl>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+            <button type="button" class="btn btn-danger ss-ok-btn" data-dismiss="modal">Terminate</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
 
     <p>
 

--- a/clj/src/slipstream/ui/views/html/table.html
+++ b/clj/src/slipstream/ui/views/html/table.html
@@ -269,7 +269,10 @@
             <td class="ss-table-cell-action-button-editable">
               <div class="input-group">
                 <span class="ss-action-button">
-                  <button class="btn btn-primary" type="button">Trigger action</button>
+                  <button class="btn btn-primary" type="button">
+                    <span class="glyphicon glyphicon-star" aria-hidden="true"></span>
+                    <span class="ss-button-label">Trigger action</span>
+                  </button>
                 </span>
               </div><!-- /input-group -->
             </td>

--- a/clj/src/slipstream/ui/views/modal_dialogs.clj
+++ b/clj/src/slipstream/ui/views/modal_dialogs.clj
@@ -71,12 +71,32 @@
     [:.ss-select-btn]         (html/content (t :button.select))))
 
 (localization/with-prefixed-t :terminate-deployment-dialog
+
   (html/defsnippet ^:private terminate-deployment-dialog template-filename [:#ss-terminate-deployment-dialog]
     []
     title-sel                 (html/content (t :title))
     body-sel                  (html/content (t :question))
     first-button-sel          (html/content (t :button.cancel))
-    last-button-sel           (html/content (t :button.terminate))))
+    last-button-sel           (html/content (t :button.terminate)))
+
+  (html/defsnippet ^:private terminate-deployment-from-table-dialog template-filename [:#ss-terminate-deployment-from-table-dialog]
+    []
+    [title-sel :#ss-terminate-deployment-from-table-dialog-label]   (html/content (t :title))
+    [body-sel :.message]                (html/content (t :question))
+    first-button-sel                    (html/content (t :button.cancel))
+    last-button-sel                     (html/content (t :button.terminate))
+    [:.ss-deployment-run-id-label]      (html/content (t :label.deployment-run-id))
+    [:.ss-deployment-run-type-label]    (html/content (t :label.deployment-run-type))
+    [:.ss-deployment-module-label]      (html/content (t :label.deployment-module))
+    [:.ss-deployment-state-label]       (html/content (t :label.deployment-state))
+    [:.ss-deployment-start-time-label]  (html/content (t :label.deployment-start-time))
+    [:.ss-deployment-clouds-label]      (html/content (t :label.deployment-clouds))
+    [:.ss-deployment-service-url-label] (html/content (t :label.deployment-service-url))
+    [:.ss-deployment-user-label]        (html/content (t :label.deployment-user))
+    [:.ss-deployment-tags-label]        (html/content (t :label.deployment-tags)))
+
+  ; end of localization/with-prefixed-t :terminate-deployment-dialog
+  )
 
 (localization/with-prefixed-t :publish-module-confirmation-dialog
   (html/defsnippet ^:private publish-module-confirmation-dialog template-filename [:#ss-publish-module-confirmation-dialog]
@@ -219,7 +239,11 @@
 
 (defn- terminate-required?
   [{:keys [view-name]}]
-  (= "run" view-name))
+  (#{"run"} view-name))
+
+(defn- terminate-from-table-required?
+  [{:keys [view-name]}]
+  (#{"dashboard" "module" "runs"} view-name))
 
 (defn- publish-required?
   [context]
@@ -265,6 +289,7 @@
                                                       (-> context :parsed-metadata :cloud-image-details :reference-image)
                                                       (-> context :parsed-metadata :summary :parent-uri))))
         (terminate-required? context)       (conj (terminate-deployment-dialog))
+        (terminate-from-table-required? context) (conj (terminate-deployment-from-table-dialog))
         (publish-required? context)         (conj (publish-module-confirmation-dialog   resource-name resource-id module-version)
                                                   (unpublish-module-confirmation-dialog resource-name resource-id module-version))
         (copy-required? context)            (conj (copy-module-dialog resource-name resource-id module-version))

--- a/clj/src/slipstream/ui/views/table.clj
+++ b/clj/src/slipstream/ui/views/table.clj
@@ -327,13 +327,14 @@
 ; Action button cell
 
 (html/defsnippet ^:private cell-action-button-snip-edit template-filename (sel-for-cell :action-button :editable)
-  [{:keys [action-type id text class size]}]
-  [:button]   (html/content   (str text))
-  [:button]   (html/add-class (str "btn-" (name (or action-type :primary))))
-  [:button]   (ue/when-add-class size (str "btn-" (name size)))
-  [:td]       (ue/when-add-class size "ss-vertical-align")
-  [:button]   (ue/when-add-class class)
-  [:button]   (ue/set-id      id))
+  [{:keys [action-type id icon text class size]}]
+  [:.glyphicon] (icons/set icon)
+  [:button :.ss-button-label] (html/content   (str text))
+  [:button]     (html/add-class (str "btn-" (name (or action-type :primary))))
+  [:button]     (ue/when-add-class size (str "btn-" (name size)))
+  [:td]         (ue/when-add-class size "ss-vertical-align")
+  [:button]     (ue/when-add-class class)
+  [:button]     (ue/set-id      id))
 
 ; Inner table cell
 
@@ -532,6 +533,11 @@
                            (assoc :text (-> content :set uc/join-as-str))
                            (dissoc :set))))
 
+; :cell/timestamp-long       "Monday, 2 March 2015, 18:50:18 CET"
+; :cell/timestamp            "Mon, 2 Mar 2015, 18:50:18 CET"
+; :cell/timestamp-short      "2 Mar 2015, 18:50:18 CET"
+; :cell/relative-timestamp   "5 months and 3 days ago"
+
 (defmethod cell-snip [:cell/timestamp-long :mode/any :content/map]
   [{content :content}]
   (cell-timestamp-snip-view content :human-readable-long :relative))
@@ -539,6 +545,10 @@
 (defmethod cell-snip [:cell/timestamp :mode/any :content/map]
   [{content :content}]
   (cell-timestamp-snip-view content :human-readable :relative))
+
+(defmethod cell-snip [:cell/timestamp-short :mode/any :content/map]
+  [{content :content}]
+  (cell-timestamp-snip-view content :human-readable-short :relative))
 
 (defmethod cell-snip [:cell/relative-timestamp :mode/any :content/map]
   [{content :content}]
@@ -551,6 +561,10 @@
 (defmethod cell-snip [:cell/timestamp :mode/any :content/plain]
   [{timestamp :content}]
   (cell-timestamp-snip-view {:timestamp timestamp} :human-readable :relative))
+
+(defmethod cell-snip [:cell/timestamp-short :mode/any :content/plain]
+  [{timestamp :content}]
+  (cell-timestamp-snip-view {:timestamp timestamp} :human-readable-short :relative))
 
 (defmethod cell-snip [:cell/relative-timestamp :mode/any :content/plain]
   [{timestamp :content}]

--- a/clj/src/slipstream/ui/views/tables.clj
+++ b/clj/src/slipstream/ui/views/tables.clj
@@ -348,7 +348,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defn- run-row
-  [{:keys [cloud-names uri module-uri start-time username uuid status display-status tags type abort-msg abort-flag?] :as run}]
+  [{:keys [cloud-names uri module-uri start-time username uuid status terminable? display-status tags type abort-msg abort-flag?] :as run}]
   {:style (case display-status
             :run-with-abort-flag-set    :danger
             :run-in-transitional-state  nil
@@ -365,16 +365,20 @@
            {:type :cell/link,      :content {:text (uc/trim-from uuid \-), :href uri}}
            {:type :cell/link,      :content {:text (u/module-name module-uri), :href module-uri}}
            {:type :cell/text,      :content status}
-           {:type :cell/timestamp, :content start-time}
+           {:type :cell/timestamp-short, :content start-time}
            {:type :cell/text,      :content cloud-names}
            {:type :cell/username,  :content username}
-           {:type :cell/text,      :content tags}]})
+           {:type :cell/text,      :content tags}
+           (when terminable?
+             {:type :cell/action-button, :content {:text (t :button-label.terminate)
+                                                   :icon (icons/icon-for :action-terminate)
+                                                   :class "ss-terminate-run-from-table-button btn-danger btn-xs"}})]})
 
 (defn runs-table
   [runs & [pagination]]
   (table/build
     {:pagination  pagination
-     :headers     [nil nil :id :module :status :start-time :cloud-names :user :tags]
+     :headers     [nil nil :id :module :status :start-time :cloud-names :user :tags :action]
      :rows        (map run-row runs)}))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/clj/test/slipstream/ui/models/runs_test.clj
+++ b/clj/test/slipstream/ui/models/runs_test.clj
@@ -24,6 +24,7 @@
          :uuid "6269f657-3311-402b-a71b-528ef76fea05"
          :type :deployment-run
          :abort-flag? false
+         :terminable? true
          :tags "tag-initializing-without-abort-flag"}
 
         {:status "Initializing"
@@ -37,6 +38,7 @@
          :uuid "53ea9de1-fff2-44d7-b053-f4fd4307b53a"
          :type :deployment-run
          :abort-flag? true
+         :terminable? true
          :tags "tag-initializing-with-abort-flag"}
 
         {:status "Provisioning"
@@ -50,6 +52,7 @@
          :uuid "e4a03073-e964-4e20-a3ab-ae0bf06c6354"
          :type :deployment-run
          :abort-flag? false
+         :terminable? true
          :tags "tag-provisioning-without-abort-flag"}
 
         {:status "Provisioning"
@@ -63,6 +66,7 @@
          :uuid "b8dd73f1-c673-451b-b95c-33fbd6b550ea"
          :type :image-build
          :abort-flag? true
+         :terminable? true
          :tags "tag-provisioning-with-abort-flag"}
 
         {:status "Executing"
@@ -76,6 +80,7 @@
          :uuid "ec745e78-be4b-43a7-83fa-6536c9d7fc92"
          :type :image-build
          :abort-flag? false
+         :terminable? true
          :tags "tag-executing-without-abort-flag"}
 
         {:status "Executing"
@@ -89,6 +94,7 @@
          :uuid "60d038d2-4069-41b5-a747-99d901f426cf"
          :type :image-build
          :abort-flag? true
+         :terminable? true
          :tags "tag-executing-with-abort-flag"}
 
         {:status "Sending reports"
@@ -102,6 +108,7 @@
          :uuid "d0ac87b8-d150-40b1-9bbb-1c8cbaf90bad"
          :type :image-build
          :abort-flag? false
+         :terminable? true
          :tags "tag-sending-reports-without-abort-flag"}
 
         {:status "Sending reports"
@@ -115,6 +122,7 @@
          :uuid "5151dc47-4bb5-4b72-990e-ab6cbd565cfc"
          :type :image-build
          :abort-flag? true
+         :terminable? true
          :tags "tag-sending-reports-with-abort-flag"}
 
         {:status "Ready"
@@ -128,6 +136,7 @@
          :uuid "c03075a0-da00-42bf-a5ad-41d13170e64e"
          :type :image-build
          :abort-flag? false
+         :terminable? true
          :tags "tag-ready-without-abort-flag"}
 
         {:status "Ready"
@@ -141,6 +150,7 @@
          :uuid "3b559cb9-1769-4c6d-aca8-9c5aea9c1662"
          :type :image-build
          :abort-flag? true
+         :terminable? true
          :tags "tag-ready-with-abort-flag"}
 
         {:status "Finalizing"
@@ -154,6 +164,7 @@
          :uuid "5842acd7-ce29-47ef-8f21-403e10db11ed"
          :type :image-build
          :abort-flag? false
+         :terminable? false
          :tags "tag-finalizing-without-abort-flag"}
 
         {:status "Finalizing"
@@ -167,6 +178,7 @@
          :uuid "555dccf8-4312-4328-8c70-b01e20a9ffa8"
          :type :deployment-run
          :abort-flag? true
+         :terminable? false
          :tags "tag-finalizing-with-very-long-abort-flag"}
 
         {:status "Done"
@@ -180,6 +192,7 @@
          :uuid "4589cc93-4c28-4362-873a-3dc84a3be58e"
          :type :deployment-run
          :abort-flag? false
+         :terminable? false
          :tags "tag-done-without-abort-flag"}
 
         {:status "Done"
@@ -193,6 +206,7 @@
          :uuid "07596eb7-f1f7-4e45-8561-5dbbc55cc817"
          :type :deployment-run
          :abort-flag? true
+         :terminable? false
          :tags "tag-done-with-abort-flag"}
 
         {:status "Aborted"
@@ -206,6 +220,7 @@
          :uuid "8ded8e5b-46ad-4bec-bcff-d761155f0e2e"
          :type :deployment-run
          :abort-flag? false
+         :terminable? false
          :tags "tag-aborted-without-abort-flag"}
 
         {:display-status :run-terminated
@@ -219,6 +234,7 @@
          :uuid "36be1b6b-d4f1-4d99-9a0f-1e65fe4bbaae"
          :type :deployment-run
          :abort-flag? true
+         :terminable? false
          :tags "tag-aborted-with-very-long-abort-flag"}
 
         {:status "Cancelled"
@@ -229,6 +245,7 @@
          :username "alice"
          :type :image-build
          :abort-flag? false
+         :terminable? false
          :tags "tag-cancelled-without-abort-flag"
          :start-time "2015-01-07 13:36:32.26 CET"
          :uri "run/b36dfcc0-b77b-4746-b7fd-0acd7038a02d"
@@ -245,6 +262,7 @@
          :start-time "2014-12-16 12:40:30.118 CET"
          :uri "run/0aa79e3f-878a-40b1-8e88-bb6808a183cc"
          :uuid "0aa79e3f-878a-40b1-8e88-bb6808a183cc"
+         :terminable? false
          :tags "tag-cancelled-with-abort-flag-1"}
 
         {:display-status :run-terminated
@@ -258,6 +276,7 @@
          :uuid "079dd5c1-85af-4387-95a7-b24fc0b2be53"
          :type :image-build
          :abort-flag? false
+         :terminable? false
          :tags "tag-cancelled-without-abort-flag"}
 
         {:status "Cancelled"
@@ -266,6 +285,7 @@
          :username "alice"
          :type :deployment-run
          :abort-flag? true
+         :terminable? false
          :tags "tag-cancelled-with-very-long-abort-flag"
          :cloud-names "Exoscale"
          :abort-msg "Cloud Username cannot be empty, please edit your <a href='/user/bob'> user account</a> b9638f6cjd19b0jd4e62jdb2f6jd498843e7aa7e6869be33jd9fe4jd4c80jdbbb1jd1665f6bad443ab7953e9jd2812jd4591jdbc8fjd194a95b9f70ed3caa272jd97a7jd4a25jd8a2ajdb13f3fd16851eb8eb8aajd163ejd4a87jd86a2jdafb2a4eb3982"

--- a/clj/test/slipstream/ui/views/table_test.clj
+++ b/clj/test/slipstream/ui/views/table_test.clj
@@ -75,6 +75,7 @@
    :cell/set                [             :content/map  :content/plain]
    :cell/timestamp-long     [             :content/map  :content/plain]
    :cell/timestamp          [             :content/map  :content/plain]
+   :cell/timestamp-short    [             :content/map  :content/plain]
    :cell/relative-timestamp [             :content/map  :content/plain]
    :cell/boolean            [             :content/map  :content/plain]
    :cell/map                [:content/any                             ]


### PR DESCRIPTION
Connected to #395 

Note that as a side effect we can now also terminate runs not only from the **Dashboard** but also from the **Module** page of the corresponding run, since the underlying `Runs` table displayed is the same in both pages.