### PR TITLE
Changed from 'mutable' to 'scalable' in the info strings displayed on UI

### DIFF
--- a/clj/resources/lang/en.edn
+++ b/clj/resources/lang/en.edn
@@ -61,7 +61,7 @@
                     :mapping          "Mapping"
                     :metering         "Metering"
                     :module           "Module"
-                    :mutable-deployment "Mutable deployment _(beta)_"
+                    :mutable-deployment "Scalable deployment _(beta)_"
                     :name             "Name"
                     :node             "Node"
                     :nodes            "Nodes"
@@ -333,7 +333,7 @@
    :slipstream.ui.views.tables.deployment-nodes-table.default-multiplicity.label                  "Default multiplicity"
    :slipstream.ui.views.tables.deployment-nodes-table.multiplicity.non-mutable-deployment.label   "Multiplicity"
    :slipstream.ui.views.tables.deployment-nodes-table.multiplicity.mutable-deployment.label       "Initial multiplicity"
-   :slipstream.ui.views.tables.deployment-nodes-table.multiplicity.non-mutable-deployment.error-help-hint "Multiplicity must be greater than 0 for non-mutable deployments."
+   :slipstream.ui.views.tables.deployment-nodes-table.multiplicity.non-mutable-deployment.error-help-hint "Multiplicity must be greater than 0 for non-scalable deployments."
    :slipstream.ui.views.tables.deployment-nodes-table.max-provisioning-failures.label             "Max provisioning failures"
    :slipstream.ui.views.tables.deployment-nodes-table.max-provisioning-failures.error-help-hint   "It must be a value strictly less than the multiplicity above."
    :slipstream.ui.views.tables.deployment-nodes-table.max-provisioning-failures.warning-help-hint "This looks like a big tolerance. Please make sure that this makes sense for this deployment."
@@ -545,7 +545,7 @@
    ;; Parameters for the global section of the 'Run deployment' dialog
 
    :slipstream.ui.models.parameters.launch-mutable-run?.description             :global.nouns.mutable-deployment
-   :slipstream.ui.models.parameters.launch-mutable-run?.help-hint               "Enabling this option will launch a _mutable_ deployment, which will allow the `multiplicity` for each node to be changed after launch. **Warning!** This is a _BETA_ feature!"
+   :slipstream.ui.models.parameters.launch-mutable-run?.help-hint               "Enabling this option will launch a _scalable_ deployment, which will allow the `multiplicity` for each node to be changed after launch. **Warning!** This is a _BETA_ feature!"
 
    :slipstream.ui.models.parameters.image-target-cloud.description              :global.nouns.cloud
    :slipstream.ui.models.parameters.image-target-cloud.help-hint                "Choose the cloud where the image will be deployed. The cloud flagged with a `*` is the default configured in your user profile. The clouds not configured (i.e. for which there are no credentials in your user profile) are disabled."
@@ -555,10 +555,10 @@
    :slipstream.ui.util.core.enum.option.text.available-clouds.specify-for-each-node "Specify for each node"
 
    :slipstream.ui.models.parameters.tolerate-deployment-failures?.description   "Tolerate deployment failures"
-   :slipstream.ui.models.parameters.tolerate-deployment-failures?.help-hint     "Enabling this option reveals a field in each node to specify how many instances (i.e. the `multiplicity` value) you tolerate to fail to properly start without SlipStream flagging the whole deployment as failed. This makes specially sense for _mutable_ deployments with a _big_ initial multiplicity."
+   :slipstream.ui.models.parameters.tolerate-deployment-failures?.help-hint     "Enabling this option reveals a field in each node to specify how many instances (i.e. the `multiplicity` value) you tolerate to fail to properly start without SlipStream flagging the whole deployment as failed. This makes specially sense for _scalable_ deployments with a _big_ initial multiplicity."
 
    :slipstream.ui.models.parameters.keep-running-behaviour.description          "Keep running after deployment"
-   :slipstream.ui.models.parameters.keep-running-behaviour.help-hint            "Here you can define if and when SlipStream should leave the application running after performing the deployment. `On success` is useful for production deployments or long tests. `On Error` might be useful so that resources are consumed only when debugging is needed. `Never` ensures that SlipStream automatically terminates the application after performing the deployment. The option flagged with a `*` is the default configured in your user profile.  Note: This parameter doesn't apply to `mutable deployment` Runs and to `build image` Runs."
+   :slipstream.ui.models.parameters.keep-running-behaviour.help-hint            "Here you can define if and when SlipStream should leave the application running after performing the deployment. `On success` is useful for production deployments or long tests. `On Error` might be useful so that resources are consumed only when debugging is needed. `Never` ensures that SlipStream automatically terminates the application after performing the deployment. The option flagged with a `*` is the default configured in your user profile.  Note: This parameter doesn't apply to `scalable deployment` Runs and to `build image` Runs."
 
    :slipstream.ui.models.parameters.mail-usage.description                      "Cloud usage email"
    :slipstream.ui.models.parameters.mail-usage.help-hint                        "The frequency at which you want to receive emails with your cloud usage."
@@ -1068,8 +1068,8 @@
 
    :slipstream.ui.views.run.orchestration.not-mutable       "Deployment run started by '%1$s' %2$s" ;; %1$s is owner's username; %2$s is relative timestamp
    :slipstream.ui.views.run.orchestration.not-mutable.own-run "Deployment run started by you (as '%1$s') %2$s" ;; %1$s is owner's username; %2$s is relative timestamp
-   :slipstream.ui.views.run.orchestration.mutable           "Mutable deployment run started by '%1$s' %2$s" ;; %1$s is owner's username; %2$s is relative timestamp
-   :slipstream.ui.views.run.orchestration.mutable.own-run   "Mutable deployment run started by you (as '%1$s') %2$s" ;; %1$s is owner's username; %2$s is relative timestamp
+   :slipstream.ui.views.run.orchestration.mutable           "Scalable deployment run started by '%1$s' %2$s" ;; %1$s is owner's username; %2$s is relative timestamp
+   :slipstream.ui.views.run.orchestration.mutable.own-run   "Scalable deployment run started by you (as '%1$s') %2$s" ;; %1$s is owner's username; %2$s is relative timestamp
 
    :slipstream.ui.views.run.section.overview.title          :global.nouns.overview
    :slipstream.ui.views.run.section.summary.title           :global.nouns.summary

--- a/clj/resources/lang/fr.edn
+++ b/clj/resources/lang/fr.edn
@@ -60,7 +60,7 @@
                     :mapping          "Liaison"
                     :metering         "Mesures"
                     :module           "Module"
-                    :mutable-deployment "Déploiement mutable _(beta)_"
+                    :mutable-deployment "Déploiement scalable _(beta)_"
                     :name             "Nom"
                     :node             "Noeud"
                     :nodes            "Noeuds"
@@ -327,7 +327,7 @@
    :slipstream.ui.views.tables.deployment-nodes-table.reference-image.label                       "Image de référence"
    :slipstream.ui.views.tables.deployment-nodes-table.default-multiplicity.label                  "Multiplicité par défaut"
    :slipstream.ui.views.tables.deployment-nodes-table.multiplicity.non-mutable-deployment.label   "Multiplicité"
-   :slipstream.ui.views.tables.deployment-nodes-table.multiplicity.non-mutable-deployment.error-help-hint "La multiplicité doit être supérieure à 0 pour les déploiements non mutables."
+   :slipstream.ui.views.tables.deployment-nodes-table.multiplicity.non-mutable-deployment.error-help-hint "La multiplicité doit être supérieure à 0 pour les déploiements non scalables."
    :slipstream.ui.views.tables.deployment-nodes-table.multiplicity.mutable-deployment.label       "Multiplicité initiale"
    :slipstream.ui.views.tables.deployment-nodes-table.max-provisioning-failures.label             "Nombre maximal d'erreurs accepté"
    :slipstream.ui.views.tables.deployment-nodes-table.max-provisioning-failures.error-help-hint   "Ceci doit être une valeur inférieure à la multiplicité ci-dessus."
@@ -539,7 +539,7 @@
    ;; Parameters for the global section of the 'Run deployment' dialog
 
    :slipstream.ui.models.parameters.launch-mutable-run?.description             :global.nouns.mutable-deployment
-   :slipstream.ui.models.parameters.launch-mutable-run?.help-hint               "Activez cette option pour lancer un déploiement _mutable_, qui permettra de modifier la `multiplicité` après le lancement. **Attention!** Ceci est une fonctionnalité en _BETA_!"
+   :slipstream.ui.models.parameters.launch-mutable-run?.help-hint               "Activez cette option pour lancer un déploiement _scalable_, qui permettra de modifier la `multiplicité` après le lancement. **Attention!** Ceci est une fonctionnalité en _BETA_!"
 
    :slipstream.ui.models.parameters.image-target-cloud.description              :global.nouns.cloud
    :slipstream.ui.models.parameters.image-target-cloud.help-hint                "Choisissez le cloud où déployer cette image. Le cloud marqué avec `*` est la valeur par défaut configurée dans votre profile. Les clouds qui ne sont pas configurés (c'est-à-dire, pour lesquels vous n'avez pas fourni d'identifiants dans votre profile) sont désactivés."
@@ -549,10 +549,10 @@
    :slipstream.ui.util.core.enum.option.text.available-clouds.specify-for-each-node "Spécifier pour chaque noeud."
 
    :slipstream.ui.models.parameters.tolerate-deployment-failures?.description   "Tolérer erreurs de déploiement"
-   :slipstream.ui.models.parameters.tolerate-deployment-failures?.help-hint     "Activez cette option pour devoiler un champ pour chaque noeud pour spécifier combien d'instances (c'est à dire, la valeur `multiplicité`) peuvent avoir des erreurs de déploiement sans que SlipStream doive marquer le déploiement au complet comme erroné. Ceci est spécialement utile pour des déploiements _mutables_ avec une _grande mutliplicité initiale."
+   :slipstream.ui.models.parameters.tolerate-deployment-failures?.help-hint     "Activez cette option pour devoiler un champ pour chaque noeud pour spécifier combien d'instances (c'est à dire, la valeur `multiplicité`) peuvent avoir des erreurs de déploiement sans que SlipStream doive marquer le déploiement au complet comme erroné. Ceci est spécialement utile pour des déploiements _scalables_ avec une _grande mutliplicité initiale."
 
    :slipstream.ui.models.parameters.keep-running-behaviour.description          "Mantenir actif après le déploiement"
-   :slipstream.ui.models.parameters.keep-running-behaviour.help-hint            "Ici vous pouvez définir si (et dans quel cas) SlipStream doit garder active l'application après l'avoir déployée. `En cas de success` est adaptée pour des déploiements de production ou pour des long tests. `En cas d'erreur` peut s'avérer utile lorsque l'on souhaite consomer des resources Cloud que dans le cas où un déverminage est nécessaire. `Jamais` s'assure que SlipStream arrête l'application après l'avoir déployée. L'option marquée avec `*` est la valeur par défaut configurée dans votre profile. Note: Ce paramètre ne s'applique pas aux `déploiements mutables` et aux `constructions d'images`."
+   :slipstream.ui.models.parameters.keep-running-behaviour.help-hint            "Ici vous pouvez définir si (et dans quel cas) SlipStream doit garder active l'application après l'avoir déployée. `En cas de success` est adaptée pour des déploiements de production ou pour des long tests. `En cas d'erreur` peut s'avérer utile lorsque l'on souhaite consomer des resources Cloud que dans le cas où un déverminage est nécessaire. `Jamais` s'assure que SlipStream arrête l'application après l'avoir déployée. L'option marquée avec `*` est la valeur par défaut configurée dans votre profile. Note: Ce paramètre ne s'applique pas aux `déploiements scalables` et aux `constructions d'images`."
 
    :slipstream.ui.models.parameters.mail-usage.description                      "Recevoir un courriel des consommations sur vos clouds"
    :slipstream.ui.models.parameters.mail-usage.help-hint                        "Choisissez la fréquence à laquelle vous recevrez un courriel détaillant la consommation de vos resources sur vos clouds."
@@ -1043,8 +1043,8 @@
    :slipstream.ui.views.run.run.not-mutable.own-run         "Image run lancé par vous (en tant que '%1$s') %2$s" ;; %1$s is owner's username; %2$s is relative timestamp
    :slipstream.ui.views.run.orchestration.not-mutable       "Exécution d'un déploiement lancé par '%1$s' %2$s" ;; %1$s is owner's username; %2$s is relative timestamp
    :slipstream.ui.views.run.orchestration.not-mutable.own-run "Exécution d'un déploiement lancé par vous (en tant que '%1$s') %2$s" ;; %1$s is owner's username; %2$s is relative timestamp
-   :slipstream.ui.views.run.orchestration.mutable           "Exécution d'un déploiement mutable lancé par '%1$s' %2$s" ;; %1$s is owner's username; %2$s is relative timestamp
-   :slipstream.ui.views.run.orchestration.mutable.own-run   "Exécution d'un déploiement mutable lancé par vous (en tant que '%1$s') %2$s" ;; %1$s is owner's username; %2$s is relative timestamp
+   :slipstream.ui.views.run.orchestration.mutable           "Exécution d'un déploiement scalable lancé par '%1$s' %2$s" ;; %1$s is owner's username; %2$s is relative timestamp
+   :slipstream.ui.views.run.orchestration.mutable.own-run   "Exécution d'un déploiement scalable lancé par vous (en tant que '%1$s') %2$s" ;; %1$s is owner's username; %2$s is relative timestamp
 
    :slipstream.ui.views.run.section.overview.title          :global.nouns.overview
    :slipstream.ui.views.run.section.summary.title           :global.nouns.summary

--- a/clj/resources/static_content/js/deployment.js
+++ b/clj/resources/static_content/js/deployment.js
@@ -411,7 +411,7 @@ jQuery( function() { ( function( $$, $, undefined ) {
                     .data("existent-value", $keepRunningBehaviourCombobox.val())
                     .val("always")
                     .closest("tr")
-                        .enableRow(false, {disableReason: "Mutable deployments are always kept running."});
+                        .enableRow(false, {disableReason: "Scalable deployments are always kept running."});
             } else {
                 $keepRunningBehaviourCombobox
                     .val($keepRunningBehaviourCombobox.data("existent-value"))


### PR DESCRIPTION
Connected to #416 

I didn't update the names of the keys/vars/etc.  They still contain 'mutable' in their names.  IMHO, it's not necessary (at least at the moment).