### PR TITLE
Input params were not shown in the run dialog for images

### DIFF
--- a/clj/src/slipstream/ui/views/modal_dialogs.clj
+++ b/clj/src/slipstream/ui/views/modal_dialogs.clj
@@ -167,7 +167,7 @@
     [:#ss-run-image-cloud-label]  (html/content       (t :cloud-service.label))
     [:.ss-run-image-global-section-title]              (html/content       (t :global-section.title))
     [:.ss-run-image-global-section-content]            (html/content       (-> [image-metadata :image] run-module-global-parameters t/run-image-global-section-table))
-    [:.ss-run-image-input-parameters-section]          (when-let [input-parameters (-> image-metadata :deployment :parameters (p/parameters-of-category "Input") not-empty)]
+    [:.ss-run-image-input-parameters-section]          (when-let [input-parameters (-> image-metadata :deployment-parameters (p/parameters-of-category "Input") not-empty)]
                                                          (ue/at-match
                                                           [:.ss-run-image-input-parameters-section-title]    (html/html-content  (t :input-parameters-section.title))
                                                           [:.ss-run-image-input-parameters-section-content]  (html/content       (t/run-image-input-parameters-table input-parameters))))


### PR DESCRIPTION
Connected to #429 

Smallest fix ever. ;)

For reference, the reason of the underlying change that caused the issue was the change on the layout of the image page sections (#362), see https://github.com/slipstream/SlipStreamUI/commit/898bcd8137b03a96d2745f1e61627e4dab6820cd.