### PR TITLE
change: request server to redirect to dashboard at run launch

### DIFF
--- a/clj/resources/static_content/js/modal_dialogs.js
+++ b/clj/resources/static_content/js/modal_dialogs.js
@@ -110,6 +110,10 @@ jQuery( function() { ( function( $$, $, undefined ) {
     // });
 
     function updateRequestForRunDeployment(request, $form) {
+        // The simple presence of the key 'redirect_to_dashboard' in the form makes the
+        // server return the proper redirect URL in the response.
+        // SOURCE: https://github.com/slipstream/SlipStreamServer/issues/455#issuecomment-142259064
+        $form.addFormHiddenField("redirect_to_dashboard", "");
         $("#ss-run-module-dialog input[type=text]")
             .each(function (){
                 // TODO: Extract this function to $.fn.extend since it's also used in creation and save forms.


### PR DESCRIPTION
Connected to #422.

Note that the tour will have to be corrected because of this change.
However, since we will also change the landing page of the application
to be the dashboard (see #423), the tour will be amended after
implementing #423.