### PR TITLE
Improve display of usage metrics

### DIFF
--- a/clj/src/slipstream/ui/util/clojure.clj
+++ b/clj/src/slipstream/ui/util/clojure.clj
@@ -423,11 +423,11 @@
 
 (defn- value-unit
   [v u]
-  (format "%.2f %s" v u))
+  (format "%.2f (%s)" v u))
 
 (defn format-metric-value
   [v m]
   (cond
-    (KB-mn-metric? m) (-> v KB-to-GB mn-to-h (value-unit "(GBh)"))
-    (GB-mn-metric? m) (-> v mn-to-h          (value-unit "(GBh)"))
-    :else             (-> v mn-to-h          (value-unit "(h)"))))
+    (KB-mn-metric? m) (-> v KB-to-GB mn-to-h (value-unit "GBh"))
+    (GB-mn-metric? m) (-> v mn-to-h          (value-unit "GBh"))
+    :else             (-> v mn-to-h          (value-unit "h"))))

--- a/clj/src/slipstream/ui/util/clojure.clj
+++ b/clj/src/slipstream/ui/util/clojure.clj
@@ -421,7 +421,7 @@
   [v]
   (/ v 1024.0))
 
-(defn value-unit
+(defn- value-unit
   [v u]
   (format "%.2f %s" v u))
 

--- a/clj/src/slipstream/ui/util/clojure.clj
+++ b/clj/src/slipstream/ui/util/clojure.clj
@@ -405,6 +405,29 @@
       (coll?    v)  (vec v)
       :else         (vector v))))
 
+(defn- KB-mn-metric?
+  [m]
+  (= "ram" (name m)))
+
+(defn- GB-mn-metric?
+  [m]
+  (= "disk" (name m)))
+
+(defn- mn-to-h
+  [v]
+  (/ v 60.0))
+
+(defn- KB-to-GB
+  [v]
+  (/ v 1024.0))
+
+(defn value-unit
+  [v u]
+  (format "%.2f %s" v u))
+
 (defn format-metric-value
-  [x]
-  (format "% ,15.2f" (double x)))
+  [v m]
+  (cond
+    (KB-mn-metric? m) (-> v KB-to-GB mn-to-h (value-unit "(GBh)"))
+    (GB-mn-metric? m) (-> v mn-to-h          (value-unit "(GBh)"))
+    :else             (-> v mn-to-h          (value-unit "(h)"))))

--- a/clj/src/slipstream/ui/views/tables.clj
+++ b/clj/src/slipstream/ui/views/tables.clj
@@ -976,7 +976,6 @@
 
 (defn- format-usage-values
   [usage]
-
   (->> usage
        (map (fn[[k v]] [k (-> v :unit_minutes (uc/format-metric-value k))]))
        (into {})))

--- a/clj/src/slipstream/ui/views/tables.clj
+++ b/clj/src/slipstream/ui/views/tables.clj
@@ -976,9 +976,9 @@
 
 (defn- format-usage-values
   [usage]
+
   (->> usage
-       (map (fn[[k v]] [k (str (-> v :unit_minutes uc/format-metric-value)
-                               " unit*minutes")]))
+       (map (fn[[k v]] [k (-> v :unit_minutes (uc/format-metric-value k))]))
        (into {})))
 
 (defn- usage-row

--- a/clj/test/slipstream/ui/util/clojure_test.clj
+++ b/clj/test/slipstream/ui/util/clojure_test.clj
@@ -1444,7 +1444,19 @@
 
 ;; format-metric-value
 
-(expect "           0.00" (format-metric-value 0.0))
-(expect "           8.00" (format-metric-value 8))
-(expect "           8.00" (format-metric-value (Integer. 8)))
-(expect "   2,468,846.93" (format-metric-value 2468846.93))
+(expect "0.27 (h)"        (format-metric-value 16.133333333333333 "instance-type.Small"))
+(expect "0.37 (h)"        (format-metric-value 22.48333333333333 "instance-type.Huge"))
+(expect "24.00 (h)"       (format-metric-value 1440.0 "instance-type.Huge"))
+(expect "1.40 (h)"        (format-metric-value 84.2 "instance-type.Medium" ))
+(expect "26.09 (h)"       (format-metric-value 1565.416666666667 "instance-type.Micro"  ))
+(expect "28.14 (h)"       (format-metric-value 1688.2333333333331 "vm"                  ))
+(expect "0.00 (h)"        (format-metric-value 0.0 "vm"))
+
+;; 47185920 is the value for Huge instance (32GB RAM) running for a full day
+;; 768 is 32 * 24
+(expect "768.00 (GBh)"    (format-metric-value 47185920.0 "ram" ))
+(expect "768.00 (GBh)"    (format-metric-value 47185920   "ram" ))
+(expect "0.00 (GBh)"      (format-metric-value 0.0        "ram" ))
+(expect "7.92 (GBh)"      (format-metric-value 474.93     "disk"))
+
+(expect "0.27 (h)"        (format-metric-value 16.133333333333333 "anything"))


### PR DESCRIPTION
Metrics are displayed per GB hour or per hour depending on the metric
name.