### PR TITLE
hotfix: root modules where created with an extra 'module' in the URL

### DIFF
--- a/clj/resources/static_content/js/model.js
+++ b/clj/resources/static_content/js/model.js
@@ -112,7 +112,7 @@ jQuery( function() { ( function( $$, model, $, undefined ) {
                                 fullName = undefined;
                             } else {
                                 moduleName = moduleName.trim();
-                                moduleParent = $$.util.url.getCurrentURLBase().removeLeadingSlash().trimPrefix("module/");
+                                moduleParent = $$.util.url.getCurrentURLBase().removeLeadingSlash().trimPrefix("module").trimPrefix("/");
                                 if (moduleParent) {
                                     fullName = moduleParent + "/" + moduleName;
                                 } else {


### PR DESCRIPTION
This fix has been hot-patched directly to nuv.la (v2.18) by myself 1h ago, i.e. on Fri, 06nov2015, 15:28 UTC.