### PR TITLE
Fallback to default SlipStream theme if it's not recognized

### DIFF
--- a/clj/src/slipstream/ui/util/localization.clj
+++ b/clj/src/slipstream/ui/util/localization.clj
@@ -18,10 +18,6 @@
     :ja
     :fr})
 
-(def ^:private available-themes
-  "See 'available-languages' above for documentation."
-  #{"helixnebula"})
-
 (def ^:private lang-resources-dir "lang")
 
 (def ^:private spot-missing-t-calls-mode? false)
@@ -39,8 +35,6 @@
   setup for the current thread."
   nil)
 
-
-
 (defn locale
   "Returns valid Locale matching given the current *lang*"
   []
@@ -51,13 +45,13 @@
 
 (defn- prefix-with-theme
   [theme k]
-  (->> k name (str theme ".") keyword))
+  (->> k name (str (name theme) ".") keyword))
 
 (defn- merge-themes-localizations
   [lang-resource-filename lang-base-dict]
   (loop [dict         lang-base-dict
-         theme        (first  available-themes)
-         next-themes  (next   available-themes)]
+         theme        (first  theme/available-themes)
+         next-themes  (next   theme/available-themes)]
     (let [theme-lang-resource-filename (str (theme/resources-folder theme) lang-resource-filename)
           lang-theme-dict (-> theme-lang-resource-filename
                               (uc/read-resource {})

--- a/clj/src/slipstream/ui/util/theme.clj
+++ b/clj/src/slipstream/ui/util/theme.clj
@@ -7,11 +7,18 @@
 ;;
 ;;       Later, the theme will be provided by the server in the metadata.
 
+(def available-themes
+  "See 'slipstream.ui.util.localization/available-languages' for documentation."
+  #{:helixnebula
+    :nuvla})
+
 (def ^:dynamic ^:private *current-theme*
+  "NB: If the theme declared in the property is not in the list above, the default
+  SlipStream theme will be used. This allows e.g. to setup 'theme=default' to use
+  the default theme."
   ; nil
-  ; "helixnebula"
-  (System/getProperty "slipstream.ui.util.theme.current-theme")
-  )
+  ; :helixnebula
+  (-> "slipstream.ui.util.theme.current-theme" System/getProperty keyword available-themes))
 
 (defn current
   []
@@ -24,10 +31,10 @@
 
 (defn static-content-folder
   [theme]
-  (when (not-empty theme)
+  (when theme
     (str themes-resources-folder "/" (name theme) "/")))
 
 (defn resources-folder
   [theme]
-  (when (not-empty theme)
+  (when theme
     (str static-content-resources-folder "/" (static-content-folder theme))))


### PR DESCRIPTION
Connected to #447.

This allows to use '-Dslipstream.ui.util.theme.current-theme=default'
to use the default SlipStream theme. Omiting it will also use the
default theme.

See https://github.com/slipstream/SlipStreamUI/issues/447