### PR TITLE
Prevent new user autofill

### DIFF
--- a/clj/resources/static_content/js/login.js
+++ b/clj/resources/static_content/js/login.js
@@ -4,9 +4,9 @@ jQuery( function() { ( function( $$, $, undefined ) {
     $$.request
         .post()
         .onErrorStatusCodeAlert(500, "Server Error",
-            "Sorry, something unexpected happend while processing your registration request.")
+            "Sorry, something unexpected happened while processing your registration request.")
         .onSuccessAlert("Registration successful",
-            "You will receive in short an email with instructions to validate the account.")
+            "You will shortly receive an email with instructions to validate the account.")
         .validation( function(){
           return $("form#register")
                       .bootstrapValidator("validate")

--- a/clj/resources/static_content/js/login.js
+++ b/clj/resources/static_content/js/login.js
@@ -7,5 +7,11 @@ jQuery( function() { ( function( $$, $, undefined ) {
             "Sorry, something unexpected happend while processing your registration request.")
         .onSuccessAlert("Registration successful",
             "You will receive in short an email with instructions to validate the account.")
+        .validation( function(){
+          return $("form#register")
+                      .bootstrapValidator("validate")
+                      .find(".form-group.has-error")
+                          .foundNothing();
+        })
         .useToSubmitForm("#register");
 }( window.SlipStream = window.SlipStream || {}, jQuery )); });

--- a/clj/src/slipstream/ui/views/html/login.html
+++ b/clj/src/slipstream/ui/views/html/login.html
@@ -30,6 +30,7 @@
             <!-- method="post" enctype="application/x-www-form-urlencoded"-->
             <form id="register"
             action="/register"
+            autocomplete="off"
             data-bv-live="enabled"
             class="form-horizontal"
             data-bv-feedbackicons-valid="glyphicon glyphicon-ok"
@@ -41,6 +42,10 @@
               <label class="sr-only" for="username">Username</label>
               <input type="text" class="form-control ss-input-pick-username" name="username"
               placeholder="Pick a username"
+
+              autocomplete="off"
+              readonly
+              onfocus="this.removeAttribute('readonly');"
 
               data-bv-message="The username is not valid"
 


### PR DESCRIPTION
Connected to #476

I've added three mechanisms to prevent wrong usernames in the self-registration form:

1. Added `autocomplete="off"` at the `form` element (not all browsers honor that though)
1. Added following attributes to `new username` field to enhance the auto-fill prevention:

    ```
    autocomplete="off"
    readonly
    onfocus="this.removeAttribute('readonly');"
    ```

1. (Re)trigger form validation before sending the request.
