### PR TITLE
Use new terminology in guided tour text.

### DIFF
--- a/clj/resources/lang/en.edn
+++ b/clj/resources/lang/en.edn
@@ -943,7 +943,7 @@
    :slipstream.ui.views.module.section.authorizations.title    :global.nouns.authorizations
 
    :slipstream.ui.views.module.project.section.children.title  :global.nouns.children
-   :slipstream.ui.views.module.project.section.children.empty-content-hint              "This project doesn't have any children yet. You can add a [new project](%3$s), [new image](%1$s) or a [new deployment](%2$s) with the corresponding actions in the menu above." ; %1$s - %3$s hrefs for new submodules
+   :slipstream.ui.views.module.project.section.children.empty-content-hint              "This project doesn't have any children yet. You can add a [new project](%3$s), [new component](%1$s) or a [new application](%2$s) with the corresponding actions in the menu above." ; %1$s - %3$s hrefs for new submodules
    :slipstream.ui.views.module.project.section.children.empty-content-hint.on-chooser   "This project doesn't have any children yet."
 
    :slipstream.ui.views.module.image.section.cloud-image-details.title                  "Cloud Image Identifiers and Image Hierarchy"

--- a/clj/resources/lang/en.edn
+++ b/clj/resources/lang/en.edn
@@ -933,11 +933,11 @@
    :slipstream.ui.views.module.help-hint.link-to-history            "The version history gives you an overview of all versions of this module and allows you to switch to a different version."
 
    :slipstream.ui.views.module.alert.view-published.title           "Published %1$s version" ;  %1$s = category: image, project or deployment; %2$s = version
-   :slipstream.ui.views.module.alert.view-published.msg!            "This version (%2$s) of the %1$s is currently published in the <a href='/'>App Store</a>." ;  %1$s = category: image, project or deployment; %2$s = version
+   :slipstream.ui.views.module.alert.view-published.msg!            "This version (%2$s) of the %1$s is currently published in the <a href='/appstore'>App Store</a>." ;  %1$s = category: image, project or deployment; %2$s = version
    :slipstream.ui.views.module.alert.view-chooser-published.title   "Published %1$s version" ;  %1$s = category: image, project or deployment; %2$s = version
-   :slipstream.ui.views.module.alert.view-chooser-published.msg!    "This version (%2$s) of the %1$s is currently published in the <a href='/'>App Store</a>." ;  %1$s = category: image, project or deployment; %2$s = version
+   :slipstream.ui.views.module.alert.view-chooser-published.msg!    "This version (%2$s) of the %1$s is currently published in the <a href='/appstore'>App Store</a>." ;  %1$s = category: image, project or deployment; %2$s = version
    :slipstream.ui.views.module.alert.edit-published.title           "Editing a published %1$s version" ;  %1$s = category: image, project or deployment; %2$s = version
-   :slipstream.ui.views.module.alert.edit-published.msg!            "Please note that the changes will not be reflected in the <a href='/' target='_blank'>App Store</a> until you publish the new saved version of this %1$s." ;  %1$s = category: image, project or deployment; %2$s = version
+   :slipstream.ui.views.module.alert.edit-published.msg!            "Please note that the changes will not be reflected in the <a href='/appstore' target='_blank'>App Store</a> until you publish the new saved version of this %1$s." ;  %1$s = category: image, project or deployment; %2$s = version
 
    :slipstream.ui.views.module.section.summary.title           :global.nouns.summary
    :slipstream.ui.views.module.section.authorizations.title    :global.nouns.authorizations
@@ -1074,14 +1074,14 @@ For more details refer to the SlipStream client <a target='_blank' href='http://
    :slipstream.ui.views.modal-dialogs.terminate-deployment-dialog.label.deployment-tags        :global.nouns.tags
 
    :slipstream.ui.views.modal-dialogs.publish-module-confirmation-dialog.title                "Publish %1$s" ;  %1$s: module category
-   :slipstream.ui.views.modal-dialogs.publish-module-confirmation-dialog.question             "Do you want to publish the %1$s `%2$s` (v %3$s) in the [App Store](/)?"  ;  %1$s: module category ;  %2$s: module name ;  %3$s: module version
+   :slipstream.ui.views.modal-dialogs.publish-module-confirmation-dialog.question             "Do you want to publish the %1$s `%2$s` (v %3$s) in the [App Store](/appstore)?"  ;  %1$s: module category ;  %2$s: module name ;  %3$s: module version
    :slipstream.ui.views.modal-dialogs.publish-module-confirmation-dialog.footnote             "Please note that the access rights still apply for published modules."
    :slipstream.ui.views.modal-dialogs.publish-module-confirmation-dialog.button.cancel        :global.verbs.cancel
    :slipstream.ui.views.modal-dialogs.publish-module-confirmation-dialog.button.publish       "Publish %1$s" ;  %1$s: module category
 
    :slipstream.ui.views.modal-dialogs.unpublish-module-confirmation-dialog.title              "Unpublish %1$s" ;  %1$s: module category
-   :slipstream.ui.views.modal-dialogs.unpublish-module-confirmation-dialog.question           "Do you want to remove the %1$s `%2$s` (v %3$s) from the [App Store](/)?"  ;  %1$s: module category ;  %2$s: module name ;  %3$s: module version
-   :slipstream.ui.views.modal-dialogs.unpublish-module-confirmation-dialog.footnote           "The %1$s will not appear on the [App Store](/) anymore, but it will still be accessibe via the projects. Please note that the access rights still apply for published modules."  ;  %1$s: module category
+   :slipstream.ui.views.modal-dialogs.unpublish-module-confirmation-dialog.question           "Do you want to remove the %1$s `%2$s` (v %3$s) from the [App Store](/appstore)?"  ;  %1$s: module category ;  %2$s: module name ;  %3$s: module version
+   :slipstream.ui.views.modal-dialogs.unpublish-module-confirmation-dialog.footnote           "The %1$s will not appear on the [App Store](/appstore) anymore, but it will still be accessibe via the projects. Please note that the access rights still apply for published modules."  ;  %1$s: module category
    :slipstream.ui.views.modal-dialogs.unpublish-module-confirmation-dialog.button.cancel      :global.verbs.cancel
    :slipstream.ui.views.modal-dialogs.unpublish-module-confirmation-dialog.button.unpublish   "Unpublish %1$s" ;  %1$s: module category
 

--- a/clj/resources/static_content/js/secondary_menu_actions.js
+++ b/clj/resources/static_content/js/secondary_menu_actions.js
@@ -107,7 +107,7 @@ jQuery( function() { ( function( $$, $, undefined ) {
                " <code class='text-success'>" + module.getFullName() + "</code>" +
                " (v " + module.getVersion() + ") was successfully " +
                (isPublished ? "published in" : "removed from") +
-               " the public <a href='/#app-store' class='text-success'>App Store</a>.";
+               " the public <a href='/appstore' class='text-success'>App Store</a>.";
     }
 
     $("#ss-secondary-menu-action-publish").clickWhenEnabled( function() {

--- a/clj/src/slipstream/ui/tour/alice.clj
+++ b/clj/src/slipstream/ui/tour/alice.clj
@@ -68,12 +68,13 @@
    :deploying-wordpress
    [
       nil
-      {:title "Run dialog"
-       :content (str "We are now on the WordPress SlipStream image page and the <span class='panel-primary'><h4 class='modal-header panel-heading'>Run image</h4></span> dialog behind has been automatically opened."
-                     " If you need to open it again, click on the menu action <span style='color:#54A9DE;background-color:#393939;font-weight:400;padding:2px 8px;'><span class='glyphicon glyphicon-cloud-upload' style='display:inline;'></span>&nbsp;Run...</span> in the right part of the page."
+      {:title "Deploy dialog"
+       :content (str "We are now on the WordPress application component page and the <span class='panel-primary'><h4 class='modal-header panel-heading'>Deploy Application Component</h4></span> dialog behind has been automatically opened."
+                     " If you need to open it again, click on the menu action <span style='color:#54A9DE;background-color:#393939;font-weight:400;padding:2px 8px;'><span class='glyphicon glyphicon-cloud-upload' style='display:inline;'></span>&nbsp;Deploy...</span> in the right part of the page."
                      " In this dialog you can specify the values of some parameters for the deployment."
                      "<br/><br/>"
-                     "Click " next-button-label " to learn how to configure and launch WordPress.")}
+                     "Click " next-button-label " to learn how to configure and launch WordPress.")
+       :width "450px"}
 
       [:#ss-run-module-dialog #{:#parameter--cloudservice :#global-cloud-service}]
       {:title "Choose the cloud"
@@ -105,7 +106,7 @@
 
       [:#ss-run-module-dialog :button.btn.btn-primary.ss-ok-btn]
       {:title "Ready to deploy"
-       :content "Click on <span style='color:#fff;background-color:#337ab7;padding: 4px 8px;font-weight:normal;'>Run image</span> when you are ready to go."
+       :content "Finally click here when you are ready to go."
        :container-sel "#ss-run-module-dialog"
        :wrap-in-elem   [:span]
        :placement "right"


### PR DESCRIPTION
Connected to SixSq/tasklist#520.

Additionally I've fixed:

1. fix: links to appstore in modal dialogs when (un)publishing apps (29e0ece)
1. fix: update hint for empty project to use new terminology (8983820)