### PR TITLE
Fixed a bug where the checkbox "Include inactive runs" ...

### DIFF
--- a/clj/resources/lang/en.edn
+++ b/clj/resources/lang/en.edn
@@ -1164,7 +1164,7 @@ For more details refer to the SlipStream client <a target='_blank' href='http://
    :slipstream.ui.views.runs.header.subtitle                "This is a sub-view of the dashboard displaying only your Runs and their status."
    :slipstream.ui.views.runs.header.second-subtitle         "Please note that this page might display the data for only one given cloud, depending on the request URL."
    :slipstream.ui.views.runs.section.runs.title             :global.nouns.runs
-   :slipstream.ui.views.runs.section.runs.empty-content-hint "You don't have any runs in this cloud."
+   :slipstream.ui.views.runs.section.runs.empty-content-hint "No Deployments were found with the current filter."
 
    :slipstream.ui.views.configuration.header.title          "System Configuration"
    :slipstream.ui.views.configuration.header.subtitle       "Configure the SlipStream service and its cloud connectors"

--- a/clj/resources/lang/fr.edn
+++ b/clj/resources/lang/fr.edn
@@ -1061,7 +1061,7 @@
    :slipstream.ui.views.runs.header.subtitle                "Ceci est une sous-vue (disponible directement dans le dashboard) affichant toutes les exécutions s'exécutants sur votre compte Cloud."
    :slipstream.ui.views.runs.header.second-subtitle         "Veuillez noter que cette page peut être limitée à un seul Cloud en fonction de l'URL demandée."
    :slipstream.ui.views.runs.section.vms.title              :global.nouns.runs
-   :slipstream.ui.views.runs.section.runs.empty-content-hint "Vous n'avez pas d'exécutions sur ce Cloud."
+   :slipstream.ui.views.runs.section.runs.empty-content-hint "Aucun déploiement n'a été trouvé avec les filtres actuels."
 
    :slipstream.ui.views.configuration.header.title          "Configuration système"
    :slipstream.ui.views.configuration.header.subtitle       "Configure le service SlipStream et ses connecteurs."

--- a/clj/src/slipstream/ui/views/runs.clj
+++ b/clj/src/slipstream/ui/views/runs.clj
@@ -13,7 +13,7 @@
   [{:title   (localization/section-title :runs)
     :content (if-let [runs (-> runs-metadata :runs not-empty)]
                (t/runs-table runs (:pagination runs-metadata) include-inactive-runs?)
-               (t :section.runs.empty-content-hint))}])
+               (t/runs-table-empty (t :section.runs.empty-content-hint) include-inactive-runs?))}])
 
 (defn page
   [metadata]

--- a/clj/src/slipstream/ui/views/tables.clj
+++ b/clj/src/slipstream/ui/views/tables.clj
@@ -398,6 +398,15 @@
      :headers     [nil nil :id :module :service-url :status :start-time :cloud-names :user :tags nil]
      :rows        (map run-row runs)}))
 
+(defn runs-table-empty
+  [empty-message & [include-inactive-runs?]]
+  (list (table/build
+     {:filters     [{:type  :boolean
+                     :id    :include-inactive-runs
+                     :value include-inactive-runs?}]})
+
+   empty-message))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (localization/with-prefixed-t :deployment-parameters-table


### PR DESCRIPTION
... in the Dashboard will not be not be displays if there is no run for the current filter.
Connected to #418 