### PR TITLE
fix: display shadows for dashboard gauges on Firefox

### DIFF
--- a/clj/resources/static_content/js/dashboard.js
+++ b/clj/resources/static_content/js/dashboard.js
@@ -167,4 +167,8 @@ jQuery( function() { ( function( $$, $, undefined ) {
         $$.util.url.redirectTo("/appstore");
     }
 
+    // NOTE: Fix for Firefox: https://github.com/slipstream/SlipStreamUI/issues/443
+    $(".ss-usage-gauge.ss-usage-gauge-drawn [filter='url(#inner-shadow)']")
+        .each(function(){ $(this).removeAttr("filter") });
+
 }( window.SlipStream = window.SlipStream || {}, jQuery ));});


### PR DESCRIPTION
Connect to #443.