### PR TITLE
Make module thumbnail in app store clickable

### DIFF
--- a/clj/resources/static_content/css/app_store.css
+++ b/clj/resources/static_content/css/app_store.css
@@ -27,7 +27,7 @@
 /* Button */
 
 .thumbnail .ss-app-image-container .btn {
-  opacity: 1;
+  opacity: .7;
   color: white;
   background-color: transparent;
   border-color: transparent;
@@ -37,10 +37,15 @@
   margin: 5%;
   right: 0;
 }
+.thumbnail .ss-app-image-container .btn:hover {
+  opacity: 1;
+}
+.thumbnail .ss-app-image-container .btn span {
+  pointer-events: none;
+}
 
 .thumbnail:hover .ss-app-image-container .btn,
 .thumbnail .ss-app-image-container .btn.ss-force-hovered-style {
-  opacity: 1;
   -webkit-box-shadow: 0 0 6px 2px rgba(80,80,80,.5);
   -moz-box-shadow: 0 0 6px 2px rgba(80,80,80,.5);
   box-shadow: 0 0 6px 2px rgba(80,80,80,.5);

--- a/clj/resources/static_content/css/content.css
+++ b/clj/resources/static_content/css/content.css
@@ -330,3 +330,7 @@ div.popover:not(.ss-alert-popover) code {
   cursor: default;
   opacity: 0.5;
 }
+
+[data-href] {
+  cursor: pointer;
+}

--- a/clj/src/slipstream/ui/views/module_list.clj
+++ b/clj/src/slipstream/ui/views/module_list.clj
@@ -52,6 +52,7 @@
                            image]
                     :as app} app-metadata-list]
     ue/this                        (ue/when-add-class (suitable-for-tour? app) "ss-example-app-in-tour")
+    app-image-container-sel        (ue/set-data :href uri)
     app-image-preloader-sel        (ue/set-src image)
     app-image-container-sel        (ue/enable-class updated? app-updated-cls)
     app-image-container-sel        (ue/enable-class new? app-new-cls)


### PR DESCRIPTION
Connected to #539

It has now the same behaviour as clicking on the module name: redirects
to the module page.