### PR TITLE
Equally named sections can now be properly open and closed

### DIFF
--- a/clj/src/slipstream/ui/views/section.clj
+++ b/clj/src/slipstream/ui/views/section.clj
@@ -31,7 +31,7 @@
   [total-section-count section-group-index sections]
   ue/this (ue/append-to-id "-" section-group-index)
   ue/this (ue/content-for section-sel [{:keys [icon title selected? content type] :as section} sections
-                   :let [section-uid (->> (or title "untitled") uc/keywordize name (str "ss-section-"))
+                   :let [section-uid (->> (or title "untitled") uc/keywordize name (str "ss-section-" (.indexOf sections section) "-"))
                          unique-section? (= total-section-count 1)
                          collapsible?    (not unique-section?)
                          flat-section?   (-> section :type (= :flat-section))]]


### PR DESCRIPTION
Connected to #612

@st @loomis @schaubl

FYI I've simply added the index of the section in the section id to
make it unique.

Note that I'm not using e.g. a rand-int because the id of the open
section goes to the url when the section is open in order to let the
browser always open this section. If it was a rand-int, the section id would
not be identifiable when the page is re-loaded, e.g. when you share the
url with somebody else.