### PR TITLE
Fixed an rendering issue on the deployment overview

### DIFF
--- a/clj/resources/static_content/js/run_overview.js
+++ b/clj/resources/static_content/js/run_overview.js
@@ -70,7 +70,7 @@ jQuery( function() { ( function( $$, $, undefined ) {
     var addNode = function(nodeName, orchestrator) {
         nodeName = nodeName.trim();
         var node = {name: nodeName, id: "id_" + nodeName, data: {type: "node"}, children: []};
-        addVm($("[id*='" + nodeName + "\\:ids']").text().split(','), node);
+        addVm($("[id*='parameter-" + nodeName + "\\:ids']").text().split(','), node);
         orchestrator.children.push(node);
     };
 


### PR DESCRIPTION
Connected to #643

If a node has a name which is a suffix (substring) of another node a ghost node instance may appear in the first node.